### PR TITLE
[MMCA-4174] Upgrade version for Non-HMRC dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import uk.gov.hmrc.DefaultBuildSettings.targetJvm
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
 lazy val appName: String = "customs-manage-authorities-frontend"
-val silencerVersion = "1.7.12"
+val silencerVersion = "1.17.13"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,22 +10,22 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.14.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.3.0",
-    "org.typelevel" %% "cats-core" % "2.3.0"
+    "org.typelevel" %% "cats-core" % "2.9.0"
   )
 
   val test: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.0.8",
     "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion,
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0",
-    "org.scalatestplus" %% "mockito-3-4" % "3.2.9.0",
-    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0",
+    "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0",
+    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0",
     "org.mockito" % "mockito-core" % "3.12.4",
     "org.pegdown" % "pegdown" % "1.6.0",
-    "org.jsoup" % "jsoup" % "1.12.1",
+    "org.jsoup" % "jsoup" % "1.16.1",
     "com.typesafe.play" %% "play-test" % PlayVersion.current,
     "org.mockito" % "mockito-all" % "1.10.19",
-    "org.scalacheck" %% "scalacheck" % "1.14.1",
-    "com.github.tomakehurst" % "wiremock-standalone" % "2.25.0",
+    "org.scalacheck" %% "scalacheck" % "1.17.0",
+    "com.github.tomakehurst" % "wiremock-standalone" % "2.27.2",
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8"
   ).map(_ % Test)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 


### PR DESCRIPTION
[Note]

A few dependencies were not updated since they were causing compatibility issues:
- `com.vladsch.flexmark:flexmark-all:test`
- `org.mockito:mockito-core:test`
- `org.scala-lang:scala-library`
- `org.scalatest:scalatest:test`

Worth creating separate ticket to tackle these 