### PR TITLE
[MMCA-4227]  - Prevent account owners to authorize their own XI EORI in Add authority journey

### DIFF
--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -110,18 +110,18 @@ class EoriNumberController @Inject()(
    */
   private def performXiEoriChecks(xiEoriNumber: Option[String],
                                   inputEoriNumber: String,
-                                  eoriAfterConversionToUpperCase: String,
+                                  eoriInUpperCase: String,
                                   mode: Mode,
                                   request: OptionalDataRequest[AnyContent],
                                   hc: HeaderCarrier,
                                   msgs: Messages): Future[Result] =
-    (xiEoriNumber, inputEoriNumber) match {
+    (xiEoriNumber, eoriInUpperCase) match {
       case (xiEori, inputEori) if xiEori.isEmpty && isXIEori(inputEori) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.register-xi-eori")(request, msgs, appConfig)
-      case (xiEori, inputEori) if xiEori.nonEmpty && isXIEori(inputEori) && inputEori.equals(xiEori.getOrElse(emptyString)) =>
+      case (xiEori, inputEori) if isOwnXiEori(xiEori, inputEori) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.authorise-own-eori")(request, msgs, appConfig)
       case _ =>
-        processValidEoriAndSubmit(mode, request, hc, msgs, eoriAfterConversionToUpperCase)
+        processValidEoriAndSubmit(mode, request, hc, msgs, eoriInUpperCase)
     }
 
   /**
@@ -204,4 +204,11 @@ class EoriNumberController @Inject()(
         userAnswers
       }
     )
+
+  /**
+   * Checks whether the provided XI EORI is user's own XI EORI
+   */
+  private def isOwnXiEori(xiEori: Option[String],
+                          inputEori: String): Boolean =
+    xiEori.nonEmpty && isXIEori(inputEori) && inputEori.equals(xiEori.getOrElse(emptyString))
 }

--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -103,9 +103,9 @@ class EoriNumberController @Inject()(
 
   /**
    * Performs below checks
-   * Empty XI EORI and its Registration
-   * Authorisation of own XI EORI
-   * if above checks fail, apt error is raised
+   * 1.Whether associated XI EORI is empty and input EORI is XI EORI
+   * 2.Whether input XI EORI is user's own XI EORI
+   * if above checks match, error is raised with relevant msg
    * else proceed to submission
    */
   private def performXiEoriChecks(xiEoriNumber: Option[String],

--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -116,7 +116,7 @@ class EoriNumberController @Inject()(
                                   hc: HeaderCarrier,
                                   msgs: Messages): Future[Result] =
     (xiEoriNumber, eoriInUpperCase) match {
-      case (xiEori, inputEori) if xiEori.isEmpty && isXIEori(inputEori) =>
+      case (xiEori, inputEori) if isNotRegisteredForXiEori(xiEori, inputEori) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.register-xi-eori")(request, msgs, appConfig)
       case (xiEori, inputEori) if isOwnXiEori(xiEori, inputEori) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.authorise-own-eori")(request, msgs, appConfig)
@@ -204,6 +204,12 @@ class EoriNumberController @Inject()(
         userAnswers
       }
     )
+
+  /**
+   * Checks whether user is registered for XI EORI
+   */
+  private def isNotRegisteredForXiEori(xiEori: Option[String],
+                                    inputEori: String) = xiEori.isEmpty && isXIEori(inputEori)
 
   /**
    * Checks whether the provided XI EORI is user's own XI EORI

--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -109,12 +109,12 @@ class EoriNumberController @Inject()(
    * else proceed to submission
    */
   private def performXiEoriChecks(xiEoriNumber: Option[String],
-                                 inputEoriNumber: String,
-                                 eoriAfterConversionToUpperCase: String,
-                                 mode: Mode,
-                                 request: OptionalDataRequest[AnyContent],
-                                 hc: HeaderCarrier,
-                                 msgs: Messages): Future[Result] =
+                                  inputEoriNumber: String,
+                                  eoriAfterConversionToUpperCase: String,
+                                  mode: Mode,
+                                  request: OptionalDataRequest[AnyContent],
+                                  hc: HeaderCarrier,
+                                  msgs: Messages): Future[Result] =
     (xiEoriNumber, inputEoriNumber) match {
       case (xiEori, inputEori) if xiEori.isEmpty && isXIEori(inputEori) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.register-xi-eori")(request, msgs, appConfig)

--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -118,7 +118,7 @@ class EoriNumberController @Inject()(
     (xiEoriNumber, inputEoriNumber) match {
       case (xiEori, inputEori) if xiEori.isEmpty && isXIEori(inputEori) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.register-xi-eori")(request, msgs, appConfig)
-      case (xiEori, inputEori) if isXIEori(inputEori) && inputEori.equals(xiEori.getOrElse(emptyString)) =>
+      case (xiEori, inputEori) if xiEori.nonEmpty && isXIEori(inputEori) && inputEori.equals(xiEori.getOrElse(emptyString)) =>
         errorView(mode, inputEoriNumber, "eoriNumber.error.authorise-own-eori")(request, msgs, appConfig)
       case _ =>
         processValidEoriAndSubmit(mode, request, hc, msgs, eoriAfterConversionToUpperCase)

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -31,6 +31,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.CSRFTokenHelper._
 import play.api.test.FakeRequest
+import utils.StringUtils.emptyString
 
 class FakeMetrics extends Metrics {
   override val defaultRegistry: MetricRegistry = new MetricRegistry
@@ -50,12 +51,13 @@ trait SpecBase extends PlaySpec with TryValues with ScalaFutures with Integratio
   def fakeRequest(method: String = "", path: String = ""): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(method, path).withCSRFToken.asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
 
-  protected def applicationBuilder(userAnswers: Option[UserAnswers] = None): GuiceApplicationBuilder =
+  protected def applicationBuilder(userAnswers: Option[UserAnswers] = None,
+                                   requestEoriNUmber: String = emptyString): GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .overrides(
         bind[DataRequiredAction].to[DataRequiredActionImpl],
         bind[IdentifierAction].to[FakeIdentifierAction],
-        bind[DataRetrievalAction].toInstance(new FakeDataRetrievalAction(userAnswers)),
+        bind[DataRetrievalAction].toInstance(new FakeDataRetrievalAction(userAnswers, requestEoriNUmber)),
         bind[Metrics].toInstance(new FakeMetrics)
       ).configure(
       "play.filters.csp.nonce.enabled" -> false

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -22,11 +22,19 @@ import utils.StringUtils.emptyString
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers], eoriNumber: String = emptyString) extends DataRetrievalAction {
+class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers], eoriNumber: String = emptyString)
+  extends DataRetrievalAction {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
-    Future.successful(OptionalDataRequest(request.request, request.internalId, request.credentials, request.affinityGroup,
-      request.name, request.email, if (eoriNumber.isEmpty) request.eoriNumber else eoriNumber, dataToReturn))
+    Future.successful(
+      OptionalDataRequest(request.request,
+        request.internalId,
+        request.credentials,
+        request.affinityGroup,
+        request.name,
+        request.email,
+        if (eoriNumber.isEmpty) request.eoriNumber else eoriNumber,
+        dataToReturn))
   }
 
   override protected implicit val executionContext: ExecutionContext =

--- a/test/controllers/actions/FakeDataRetrievalAction.scala
+++ b/test/controllers/actions/FakeDataRetrievalAction.scala
@@ -18,14 +18,15 @@ package controllers.actions
 
 import models.UserAnswers
 import models.requests.{IdentifierRequest, OptionalDataRequest}
+import utils.StringUtils.emptyString
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends DataRetrievalAction {
+class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers], eoriNumber: String = emptyString) extends DataRetrievalAction {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] = {
     Future.successful(OptionalDataRequest(request.request, request.internalId, request.credentials, request.affinityGroup,
-      request.name, request.email, request.eoriNumber, dataToReturn))
+      request.name, request.email, if (eoriNumber.isEmpty) request.eoriNumber else eoriNumber, dataToReturn))
   }
 
   override protected implicit val executionContext: ExecutionContext =

--- a/test/controllers/add/EoriNumberControllerSpec.scala
+++ b/test/controllers/add/EoriNumberControllerSpec.scala
@@ -294,9 +294,8 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
       }
     }
 
-    //TODO: This should be revisited as need to find a way to reset the different eoriNumber value in OptionalDataRequest
     "redirect to EoriDetailsCorrect page when form data is valid, request eori is different to UserAnswers eori" +
-      "and user in CheckMode" ignore new SetUp {
+      "and user in CheckMode" in new SetUp {
       when(mockConnector.validateEori(any())(any())).thenReturn(Future.successful(Right(true)))
 
       val mockSessionRepository: SessionRepository = mock[SessionRepository]
@@ -305,14 +304,14 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
 
       val application: Application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers.set(
-          EoriNumberPage, CompanyDetails("gb123456789011", None)).success.value))
+          EoriNumberPage, CompanyDetails("gb123456789011", None)).success.value),
+          requestEoriNUmber = "gb123456789033")
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(
               controllers.add.routes.EoriDetailsCorrectController.onPageLoad(CheckMode), mode = CheckMode)),
             bind[CustomsFinancialsConnector].toInstance(mockConnector),
             bind[SessionRepository].toInstance(mockSessionRepository)
-          )
-          .build()
+          ).build()
 
       running(application) {
 
@@ -322,10 +321,9 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
 
         val result = route(application, request).value
 
-        status(result) mustEqual BAD_REQUEST //Should be SEE_OTHER
-        // Below would be uncommented once we find a way to set diff eoriNumber value in OptionalDataRequest
-        //redirectLocation(result).value mustEqual
-        // controllers.add.routes.EoriDetailsCorrectController.onPageLoad(NormalMode).url
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual
+          controllers.add.routes.EoriDetailsCorrectController.onPageLoad(CheckMode).url
       }
     }
 


### PR DESCRIPTION
Below has been done as part this PR

- Test addition and relevant code changes
- Ignored test has been reintroduced 
- FakeDataRetrievalAction has ben updated to handle the explicit Eori number in order  to write the test with request containing custom Eori number