### PR TITLE
[MMCA-4339] - XI EORI - Owner EORI mapping on ACC30 request for CAN and GAN

### DIFF
--- a/app/controllers/add/AuthorisedUserController.scala
+++ b/app/controllers/add/AuthorisedUserController.scala
@@ -101,7 +101,7 @@ class AuthorisedUserController @Inject()(override val messagesApi: MessagesApi,
                                       xiEori: String,
                                       gbEori: String,
                                       payload: AddAuthorityRequest)(implicit hc: HeaderCarrier): Future[Result] = {
-    val grantAccAuthRequests: Seq[GrantAccountAuthorityRequest] =  grantAccountAuthRequestList(payload, xiEori, gbEori)
+    val grantAccAuthRequests: Seq[GrantAccountAuthorityRequest] = grantAccountAuthRequestList(payload, xiEori, gbEori)
 
     for {
       result <- Future.sequence(grantAccAuthRequests.map {

--- a/app/controllers/add/AuthorisedUserController.scala
+++ b/app/controllers/add/AuthorisedUserController.scala
@@ -19,7 +19,7 @@ package controllers.add
 import config.FrontendAppConfig
 import connectors.{CustomsDataStoreConnector, CustomsFinancialsConnector}
 import controllers.actions._
-import controllers.{GrantAccountAuthorityRequest, addAuthRequestList}
+import controllers.grantAccountAuthRequestList
 import forms.AuthorisedUserFormProviderWithConsent
 import models.requests.{AddAuthorityRequest, GrantAccountAuthorityRequest}
 import models.{NormalMode, UserAnswers}
@@ -101,14 +101,7 @@ class AuthorisedUserController @Inject()(override val messagesApi: MessagesApi,
                                       xiEori: String,
                                       gbEori: String,
                                       payload: AddAuthorityRequest)(implicit hc: HeaderCarrier): Future[Result] = {
-    val addAuthRequests = addAuthRequestList(payload)
-    val ownerEoriList = List(xiEori, gbEori)
-
-    val ownerEoriAndRequestMapping: Seq[(String, AddAuthorityRequest)] = ownerEoriList.zip(addAuthRequests)
-
-    val grantAccAuthRequests: Seq[GrantAccountAuthorityRequest] = ownerEoriAndRequestMapping.map {
-      eoriAndRequest => GrantAccountAuthorityRequest(eoriAndRequest._2, eoriAndRequest._1)
-    }
+    val grantAccAuthRequests: Seq[GrantAccountAuthorityRequest] =  grantAccountAuthRequestList(payload, xiEori, gbEori)
 
     for {
       result <- Future.sequence(grantAccAuthRequests.map {

--- a/app/controllers/add/AuthorisedUserController.scala
+++ b/app/controllers/add/AuthorisedUserController.scala
@@ -17,9 +17,11 @@
 package controllers.add
 
 import config.FrontendAppConfig
-import connectors.CustomsFinancialsConnector
+import connectors.{CustomsDataStoreConnector, CustomsFinancialsConnector}
 import controllers.actions._
+import controllers.{GrantAccountAuthorityRequest, addAuthRequestList}
 import forms.AuthorisedUserFormProviderWithConsent
+import models.requests.{AddAuthorityRequest, GrantAccountAuthorityRequest}
 import models.{NormalMode, UserAnswers}
 import navigation.Navigator
 import pages.add.AuthorisedUserPage
@@ -30,9 +32,10 @@ import services.DateTimeService
 import services.add.{AddAuthorityValidationService, CheckYourAnswersValidationService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.StringUtils.nIEORIPrefix
 import viewmodels.CheckYourAnswersHelper
 import views.html.add.AuthorisedUserView
-import connectors.CustomsDataStoreConnector
+
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -76,16 +79,51 @@ class AuthorisedUserController @Inject()(override val messagesApi: MessagesApi,
         Future.successful(errorPage("UserAnswers did not contain sufficient data to construct add authority request"))
       ) { payload =>
         val enteredEori = (userAnswers.data \ "eoriNumber" \ "eori").as[String]
-        val ownerEori = if(enteredEori.startsWith("XI")) xiEori else gbEori
-        connector.grantAccountAuthorities(payload, ownerEori).map {
-          case true => Redirect(navigator.nextPage(AuthorisedUserPage, NormalMode, userAnswers))
-          case false => errorPage(("Add authority request submission to backend failed", payload))
+        val ownerEori = if (enteredEori.startsWith(nIEORIPrefix)) xiEori else gbEori
+
+        if (enteredEori.startsWith(nIEORIPrefix)) {
+          processPayloadForXIEori(userAnswers, xiEori, gbEori, payload)
+        } else {
+          connector.grantAccountAuthorities(payload, ownerEori).map {
+            case true => Redirect(navigator.nextPage(AuthorisedUserPage, NormalMode, userAnswers))
+            case false => errorPage(("Add authority request submission to backend failed", payload))
+          }
         }
       }
   }
 
+  /**
+   * Sends two calls to grant authority if Accounts has both DD (with XI ownerEORI )
+   *   and Cash/Guarantee accounts (with GB EORI as ownerEORI)
+   * Sends only one call if Accounts has only DD account
+   */
+  private def processPayloadForXIEori(userAnswers: UserAnswers,
+                                      xiEori: String,
+                                      gbEori: String,
+                                      payload: AddAuthorityRequest)(implicit hc: HeaderCarrier): Future[Result] = {
+    val addAuthRequests = addAuthRequestList(payload)
+    val ownerEoriList = List(xiEori, gbEori)
 
-  private def errorPage(msg:String) = {
+    val ownerEoriAndRequestMapping: Seq[(String, AddAuthorityRequest)] = ownerEoriList.zip(addAuthRequests)
+
+    val grantAccAuthRequests: Seq[GrantAccountAuthorityRequest] = ownerEoriAndRequestMapping.map {
+      eoriAndRequest => GrantAccountAuthorityRequest(eoriAndRequest._2, eoriAndRequest._1)
+    }
+
+    for {
+      result <- Future.sequence(grantAccAuthRequests.map {
+        req => connector.grantAccountAuthorities(req.payload, req.ownerEori)
+      })
+    } yield {
+      if (result.contains(false)) {
+        errorPage(("Add authority request submission to backend failed", payload))
+      } else {
+        Redirect(navigator.nextPage(AuthorisedUserPage, NormalMode, userAnswers))
+      }
+    }
+  }
+
+  private def errorPage(msg:String): Result = {
     logger.error(msg)
     Redirect(controllers.routes.TechnicalDifficulties.onPageLoad)
   }

--- a/app/controllers/edit/EditCheckYourAnswersController.scala
+++ b/app/controllers/edit/EditCheckYourAnswersController.scala
@@ -19,8 +19,9 @@ package controllers.edit
 import config.FrontendAppConfig
 import connectors.{CustomsDataStoreConnector, CustomsFinancialsConnector}
 import controllers.actions._
+import controllers.grantAccountAuthRequestList
 import models.domain.AccountWithAuthoritiesWithId
-import models.requests.DataRequest
+import models.requests.{AddAuthorityRequest, DataRequest, GrantAccountAuthorityRequest}
 import models.{ErrorResponse, MissingAccountError, MissingAuthorityError, NormalMode, UserAnswers}
 import navigation.Navigator
 import pages.edit._
@@ -31,6 +32,7 @@ import services._
 import services.edit.EditAuthorityValidationService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.StringUtils.nIEORIPrefix
 import viewmodels.CheckYourAnswersEditHelper
 import views.html.edit.EditCheckYourAnswersView
 
@@ -85,22 +87,58 @@ class EditCheckYourAnswersController @Inject()(override val messagesApi: Message
                            authorityId: String,
                            authorisedEori: String,
                            account: AccountWithAuthoritiesWithId,
-                           xiEori: String, gbEori: String)(implicit hc: HeaderCarrier): Future[Result] = {
+                           xiEori: String,
+                           gbEori: String)(implicit hc: HeaderCarrier): Future[Result] = {
 
-    val ownerEori = if(authorisedEori.startsWith("XI")) xiEori else gbEori
+    val ownerEori = if(authorisedEori.startsWith(nIEORIPrefix)) xiEori else gbEori
 
     editAuthorityValidationService.validate(userAnswers, accountId, authorityId, authorisedEori, account) match {
-      case Right(payload) => connector.grantAccountAuthorities(payload, ownerEori).map {
-        case true => Redirect(navigator.nextPage(EditCheckYourAnswersPage(accountId, authorityId), NormalMode, userAnswers))
-        case false =>
-          logger.error("Edit authority request submission to backend failed")
-          Redirect(controllers.routes.TechnicalDifficulties.onPageLoad)
-      }
+      case Right(payload) =>
+        if(authorisedEori.startsWith(nIEORIPrefix)) {
+          processPayloadForXIEori(userAnswers, xiEori, gbEori, payload, accountId, authorityId)
+        } else {
+          connector.grantAccountAuthorities(payload, ownerEori).map {
+            case true =>
+              Redirect(navigator.nextPage(EditCheckYourAnswersPage(accountId, authorityId), NormalMode, userAnswers))
+            case false =>
+              logger.error("Edit authority request submission to backend failed")
+              Redirect(controllers.routes.TechnicalDifficulties.onPageLoad)
+          }
+        }
+
       case _ =>
         logger.error("UserAnswers did not contain sufficient data to construct add authority request")
         Future.successful(Redirect(controllers.routes.TechnicalDifficulties.onPageLoad))
     }
   }
+
+  /**
+   * Sends two calls to grant authority if Accounts has both DD (with XI ownerEORI )
+   * and Cash/Guarantee accounts (with GB EORI as ownerEORI)
+   * Sends only one call if Accounts has only DD account
+   */
+  private def processPayloadForXIEori(userAnswers: UserAnswers,
+                                      xiEori: String,
+                                      gbEori: String,
+                                      payload: AddAuthorityRequest,
+                                      accountId: String,
+                                      authorityId: String)(implicit hc: HeaderCarrier): Future[Result] = {
+    val grantAccAuthRequests: Seq[GrantAccountAuthorityRequest] = grantAccountAuthRequestList(payload, xiEori, gbEori)
+
+    for {
+      result <- Future.sequence(grantAccAuthRequests.map {
+        req => connector.grantAccountAuthorities(req.payload, req.ownerEori)
+      })
+    } yield {
+      if (result.contains(false)) {
+        logger.error("Edit authority request submission to backend failed")
+        Redirect(controllers.routes.TechnicalDifficulties.onPageLoad)
+      } else {
+        Redirect(navigator.nextPage(EditCheckYourAnswersPage(accountId, authorityId), NormalMode, userAnswers))
+      }
+    }
+  }
+
 
   private def errorPage(error: ErrorResponse): Result = {
     logger.error(error.msg)

--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import models.requests.AddAuthorityRequest
+
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package object controllers {
+
+  def addAuthRequestList(payload: AddAuthorityRequest): List[AddAuthorityRequest] = {
+    val accounts = payload.accounts
+
+    if (accounts.hasOnlyDutyDefermentsAccount) {
+      List(payload)
+    } else {
+      val ddAccountAuthReq = payload.copy(accounts = accounts.copy(cash = None, guarantee = None))
+      val cashAndGuaranteeAccountAuthRequest = payload.copy(accounts = accounts.copy(dutyDeferments = Seq()))
+
+      List(ddAccountAuthReq, cashAndGuaranteeAccountAuthRequest)
+    }
+  }
+}

--- a/app/models/requests/ManageAuthorityRequests.scala
+++ b/app/models/requests/ManageAuthorityRequests.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{Format, Json, OFormat}
 
 case class Accounts(cash: Option[String], dutyDeferments: Seq[String], guarantee: Option[String]) {
   def hasOnlyDutyDefermentsAccount: Boolean = cash.isEmpty && guarantee.isEmpty
+
   def isDutyDefermentsAccountEmpty: Boolean = dutyDeferments.isEmpty
 }
 
@@ -52,4 +53,4 @@ object RevokeAuthorityRequest {
   implicit val revokeAuthorityRequestFormat: OFormat[RevokeAuthorityRequest] = Json.format[RevokeAuthorityRequest]
 }
 
-case class GrantAccountAuthorityRequest(payload: AddAuthorityRequest , ownerEori: String)
+case class GrantAccountAuthorityRequest(payload: AddAuthorityRequest, ownerEori: String)

--- a/app/models/requests/ManageAuthorityRequests.scala
+++ b/app/models/requests/ManageAuthorityRequests.scala
@@ -19,7 +19,10 @@ package models.requests
 import models.domain.{AccountType, AuthorisedUser, StandingAuthority}
 import play.api.libs.json.{Format, Json, OFormat}
 
-case class Accounts(cash: Option[String], dutyDeferments: Seq[String], guarantee: Option[String])
+case class Accounts(cash: Option[String], dutyDeferments: Seq[String], guarantee: Option[String]) {
+  def hasOnlyDutyDefermentsAccount: Boolean = cash.isEmpty && guarantee.isEmpty
+  def isDutyDefermentsAccountEmpty: Boolean = dutyDeferments.isEmpty
+}
 
 object Accounts {
 
@@ -49,3 +52,4 @@ object RevokeAuthorityRequest {
   implicit val revokeAuthorityRequestFormat: OFormat[RevokeAuthorityRequest] = Json.format[RevokeAuthorityRequest]
 }
 
+case class GrantAccountAuthorityRequest(payload: AddAuthorityRequest , ownerEori: String)

--- a/test/controllers/PackageSpec.scala
+++ b/test/controllers/PackageSpec.scala
@@ -24,19 +24,19 @@ import java.time.LocalDate
 
 class PackageSpec extends SpecBase {
   "grantAccountAuthRequestList" should {
-    "return list of two request when accounts has both DD and Cash/Guarantee accounts" in new Setup {
+    "return list of two requests when accounts has both DD and Cash/Guarantee accounts" in new Setup {
       grantAccountAuthRequestList(authReq, xiEori, gbEori) mustBe
         List(GrantAccountAuthorityRequest(authReqForDDAccount, xiEori),
           GrantAccountAuthorityRequest(authReqForCashAndGuaranteeAccount, gbEori))
     }
 
     "return request list with only one request when accounts has only duty deferments account" in new Setup {
-      grantAccountAuthRequestList(authReqWithDDAccountsOnly,xiEori, gbEori) mustBe
+      grantAccountAuthRequestList(authReqWithDDAccountsOnly, xiEori, gbEori) mustBe
         List(GrantAccountAuthorityRequest(authReqWithDDAccountsOnly, xiEori))
     }
 
     "return request list with only one request when accounts has no duty deferments account" in new Setup {
-      grantAccountAuthRequestList(authReqWithNoDDAccounts,xiEori, gbEori) mustBe
+      grantAccountAuthRequestList(authReqWithNoDDAccounts, xiEori, gbEori) mustBe
         List(GrantAccountAuthorityRequest(authReqWithNoDDAccounts, gbEori))
     }
   }

--- a/test/controllers/PackageSpec.scala
+++ b/test/controllers/PackageSpec.scala
@@ -18,28 +18,35 @@ package controllers
 
 import base.SpecBase
 import models.domain.{AuthorisedUser, StandingAuthority}
-import models.requests.{Accounts, AddAuthorityRequest}
+import models.requests.{Accounts, AddAuthorityRequest, GrantAccountAuthorityRequest}
 
 import java.time.LocalDate
 
 class PackageSpec extends SpecBase {
-  "addAuthRequestList" should {
-    "return correct output" in new Setup {
-      addAuthRequestList(authReq) mustBe List(authReqForDDAccount, authReqForCashAndGuaranteeAccount)
+  "grantAccountAuthRequestList" should {
+    "return list of two request when accounts has both DD and Cash/Guarantee accounts" in new Setup {
+      grantAccountAuthRequestList(authReq, xiEori, gbEori) mustBe
+        List(GrantAccountAuthorityRequest(authReqForDDAccount, xiEori),
+          GrantAccountAuthorityRequest(authReqForCashAndGuaranteeAccount, gbEori))
     }
 
-    "request list with only one request when accounts has only duty deferments account" in new Setup {
-      addAuthRequestList(authReqWithDDAccountsOnly) mustBe List(authReqWithDDAccountsOnly)
+    "return request list with only one request when accounts has only duty deferments account" in new Setup {
+      grantAccountAuthRequestList(authReqWithDDAccountsOnly,xiEori, gbEori) mustBe
+        List(GrantAccountAuthorityRequest(authReqWithDDAccountsOnly, xiEori))
     }
 
-    "request list with only one request when accounts has no duty deferments account" in new Setup {
-      addAuthRequestList(authReqWithDDAccountsOnly) mustBe List(authReqWithDDAccountsOnly)
+    "return request list with only one request when accounts has no duty deferments account" in new Setup {
+      grantAccountAuthRequestList(authReqWithNoDDAccounts,xiEori, gbEori) mustBe
+        List(GrantAccountAuthorityRequest(authReqWithNoDDAccounts, gbEori))
     }
   }
 
   trait Setup {
     val localDate: LocalDate = LocalDate.now()
     val toLocalDate: LocalDate = LocalDate.now().plusDays(1)
+
+    val xiEori = "XI123456789012"
+    val gbEori = "GB123456789012"
 
     val authReq: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(Some("12345"), Seq("67890"), Some("12345678")),
@@ -49,6 +56,12 @@ class PackageSpec extends SpecBase {
 
     val authReqWithDDAccountsOnly: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(None, Seq("67890"), None),
+      StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
+      AuthorisedUser("name", "job")
+    )
+
+    val authReqWithNoDDAccounts: AddAuthorityRequest = AddAuthorityRequest(
+      Accounts(Some("12345"), Seq(), None),
       StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
       AuthorisedUser("name", "job")
     )

--- a/test/controllers/PackageSpec.scala
+++ b/test/controllers/PackageSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import models.domain.{AuthorisedUser, StandingAuthority}
+import models.requests.{Accounts, AddAuthorityRequest}
+
+import java.time.LocalDate
+
+class PackageSpec extends SpecBase {
+  "addAuthRequestList" should {
+    "return correct output" in new Setup {
+      addAuthRequestList(authReq) mustBe List(authReqForDDAccount, authReqForCashAndGuaranteeAccount)
+    }
+
+    "request list with only one request when accounts has only duty deferments account" in new Setup {
+      addAuthRequestList(authReqWithDDAccountsOnly) mustBe List(authReqWithDDAccountsOnly)
+    }
+
+    "request list with only one request when accounts has no duty deferments account" in new Setup {
+      addAuthRequestList(authReqWithDDAccountsOnly) mustBe List(authReqWithDDAccountsOnly)
+    }
+  }
+
+  trait Setup {
+    val localDate: LocalDate = LocalDate.now()
+    val toLocalDate: LocalDate = LocalDate.now().plusDays(1)
+
+    val authReq: AddAuthorityRequest = AddAuthorityRequest(
+      Accounts(Some("12345"), Seq("67890"), Some("12345678")),
+      StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
+      AuthorisedUser("name", "job")
+    )
+
+    val authReqWithDDAccountsOnly: AddAuthorityRequest = AddAuthorityRequest(
+      Accounts(None, Seq("67890"), None),
+      StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
+      AuthorisedUser("name", "job")
+    )
+
+    val authReqForCashAndGuaranteeAccount: AddAuthorityRequest = AddAuthorityRequest(
+      Accounts(Some("12345"), Seq(), Some("12345678")),
+      StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
+      AuthorisedUser("name", "job")
+    )
+
+    val authReqForDDAccount: AddAuthorityRequest = AddAuthorityRequest(
+      Accounts(None, Seq("67890"), None),
+      StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
+      AuthorisedUser("name", "job")
+    )
+  }
+}

--- a/test/controllers/add/AuthorisedUserControllerSpec.scala
+++ b/test/controllers/add/AuthorisedUserControllerSpec.scala
@@ -24,8 +24,9 @@ import forms.AuthorisedUserFormProviderWithConsent
 import models.domain._
 import models.requests.Accounts
 import models.{AuthorityStart, CompanyDetails, EoriDetailsCorrect, ShowBalance, UserAnswers}
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import pages.add._
 import play.api.data.Form
@@ -159,6 +160,129 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
       }
     }
 
+    "redirect to next page for valid data when user has selected cash,guarantee and DD accounts " +
+      "and input EORI is XI EORI" in new SetUp {
+      val userAnswers: UserAnswers = userAnswersTodayToIndefiniteWithXIEori.set(
+        AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
+
+      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
+
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("XI9876543210000"))(any)).thenReturn(Future.successful(true))
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("GB123456789012"))(any)).thenReturn(Future.successful(true))
+
+      val application: Application = applicationBuilder(Some(userAnswers), "GB123456789012")
+        .overrides(
+          inject.bind[CustomsFinancialsConnector].toInstance(mockConnector),
+          inject.bind[CheckYourAnswersValidationService].toInstance(mockValidator),
+          inject.bind[VerifyAccountNumbersAction].toInstance(new FakeVerifyAccountNumbersAction(userAnswers)),
+          inject.bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
+        ).build()
+
+      running(application) {
+        val request = fakeRequest(POST, onSubmitRoute)
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        //redirectLocation(result) mustBe
+        verify(mockConnector, Mockito.times(2)).grantAccountAuthorities(any, any)(any)
+      }
+    }
+
+    "redirect to error page for valid data when user has selected cash,guarantee and DD accounts " +
+      "and input EORI is XI EORI but grant authority calls fail" in new SetUp {
+      val userAnswers: UserAnswers = userAnswersTodayToIndefiniteWithXIEori.set(
+        AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
+
+      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
+
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("XI9876543210000"))(any)).thenReturn(Future.successful(false))
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("GB123456789012"))(any)).thenReturn(Future.successful(false))
+
+      val application: Application = applicationBuilder(Some(userAnswers), "GB123456789012")
+        .overrides(
+          inject.bind[CustomsFinancialsConnector].toInstance(mockConnector),
+          inject.bind[CheckYourAnswersValidationService].toInstance(mockValidator),
+          inject.bind[VerifyAccountNumbersAction].toInstance(new FakeVerifyAccountNumbersAction(userAnswers)),
+          inject.bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
+        ).build()
+
+      running(application) {
+        val request = fakeRequest(POST, onSubmitRoute)
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result) mustBe Some(controllers.routes.TechnicalDifficulties.onPageLoad.url)
+
+        verify(mockConnector, Mockito.times(2)).grantAccountAuthorities(any, any)(any)
+      }
+    }
+
+    "redirect to error page for valid data when user has selected cash,guarantee and DD accounts " +
+      "and input EORI is XI EORI but one of grant authority call fails" in new SetUp {
+      val userAnswers: UserAnswers = userAnswersTodayToIndefiniteWithXIEori.set(
+        AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
+
+      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
+
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("XI9876543210000"))(any)).thenReturn(Future.successful(true))
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("GB123456789012"))(any)).thenReturn(Future.successful(false))
+
+      val application: Application = applicationBuilder(Some(userAnswers), "GB123456789012")
+        .overrides(
+          inject.bind[CustomsFinancialsConnector].toInstance(mockConnector),
+          inject.bind[CheckYourAnswersValidationService].toInstance(mockValidator),
+          inject.bind[VerifyAccountNumbersAction].toInstance(new FakeVerifyAccountNumbersAction(userAnswers)),
+          inject.bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
+        ).build()
+
+      running(application) {
+        val request = fakeRequest(POST, onSubmitRoute)
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result) mustBe Some(controllers.routes.TechnicalDifficulties.onPageLoad.url)
+
+        verify(mockConnector, Mockito.times(2)).grantAccountAuthorities(any, any)(any)
+      }
+    }
+
+    "redirect to next page for valid data when user has selected cash,guarantee and DD accounts " +
+      "and input EORI is GB EORI" in new SetUp {
+      val userAnswers: UserAnswers = userAnswersTodayToIndefinite.set(
+        AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
+
+      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
+      when(mockConnector.grantAccountAuthorities(
+        any, ArgumentMatchers.eq("GB123456789012"))(any)).thenReturn(Future.successful(true))
+
+      val application: Application = applicationBuilder(Some(userAnswers))
+        .overrides(
+          inject.bind[CustomsFinancialsConnector].toInstance(mockConnector),
+          inject.bind[CheckYourAnswersValidationService].toInstance(mockValidator),
+          inject.bind[VerifyAccountNumbersAction].toInstance(new FakeVerifyAccountNumbersAction(userAnswers)),
+          inject.bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
+        ).build()
+
+      running(application) {
+        val request = fakeRequest(POST, onSubmitRoute)
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        verify(mockConnector, Mockito.times(1)).grantAccountAuthorities(any, any)(any)
+      }
+    }
+
     "redirect to TechnicalDifficulties page for invalid data" in new SetUp {
       val userAnswers: UserAnswers = userAnswersTodayToIndefinite.set(AccountsPage, List(cashAccount)).success.value
 
@@ -220,6 +344,14 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
     val userAnswersTodayToIndefinite: UserAnswers = UserAnswers("id")
       .set(AccountsPage, selectedAccounts).success.value
       .set(EoriNumberPage, CompanyDetails("GB123456789012", Some("companyName"))).success.value
+      .set(AuthorityStartPage, AuthorityStart.Today)(AuthorityStart.writes).success.value
+      .set(EoriDetailsCorrectPage, EoriDetailsCorrect.Yes)(EoriDetailsCorrect.writes).success.value
+      .set(ShowBalancePage, ShowBalance.Yes)(ShowBalance.writes).success.value
+      .set(AuthorityDetailsPage, AuthorisedUser("", "")).success.value
+
+    val userAnswersTodayToIndefiniteWithXIEori: UserAnswers = UserAnswers("id")
+      .set(AccountsPage, selectedAccounts).success.value
+      .set(EoriNumberPage, CompanyDetails("XI9876543210000", Some("companyName"))).success.value
       .set(AuthorityStartPage, AuthorityStart.Today)(AuthorityStart.writes).success.value
       .set(EoriDetailsCorrectPage, EoriDetailsCorrect.Yes)(EoriDetailsCorrect.writes).success.value
       .set(ShowBalancePage, ShowBalance.Yes)(ShowBalance.writes).success.value

--- a/test/controllers/add/AuthorisedUserControllerSpec.scala
+++ b/test/controllers/add/AuthorisedUserControllerSpec.scala
@@ -165,7 +165,8 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
       val userAnswers: UserAnswers = userAnswersTodayToIndefiniteWithXIEori.set(
         AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
 
-      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockValidator.validate(userAnswers)).thenReturn(
+        Some((accountsWithDDCashAndGuarantee, standingAuthority, authorisedUser)))
       when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
 
       when(mockConnector.grantAccountAuthorities(
@@ -186,7 +187,6 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
-        //redirectLocation(result) mustBe
         verify(mockConnector, Mockito.times(2)).grantAccountAuthorities(any, any)(any)
       }
     }
@@ -196,7 +196,8 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
       val userAnswers: UserAnswers = userAnswersTodayToIndefiniteWithXIEori.set(
         AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
 
-      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockValidator.validate(userAnswers)).thenReturn(
+        Some((accountsWithDDCashAndGuarantee, standingAuthority, authorisedUser)))
       when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
 
       when(mockConnector.grantAccountAuthorities(
@@ -228,7 +229,8 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
       val userAnswers: UserAnswers = userAnswersTodayToIndefiniteWithXIEori.set(
         AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
 
-      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockValidator.validate(userAnswers)).thenReturn(
+        Some((accountsWithDDCashAndGuarantee, standingAuthority, authorisedUser)))
       when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
 
       when(mockConnector.grantAccountAuthorities(
@@ -260,7 +262,8 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
       val userAnswers: UserAnswers = userAnswersTodayToIndefinite.set(
         AccountsPage, List(cashAccount, generalGuarantee, dutyDeferment)).success.value
 
-      when(mockValidator.validate(userAnswers)).thenReturn(Some((accounts, standingAuthority, authorisedUser)))
+      when(mockValidator.validate(userAnswers)).thenReturn(
+        Some((accountsWithDDCashAndGuarantee, standingAuthority, authorisedUser)))
       when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some("XI9876543210000")))
       when(mockConnector.grantAccountAuthorities(
         any, ArgumentMatchers.eq("GB123456789012"))(any)).thenReturn(Future.successful(true))
@@ -321,6 +324,11 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
 
     val accounts: Accounts = Accounts(
       Some(AccountWithAuthorities(CdsCashAccount, "12345", Some(AccountStatusOpen), Seq.empty)), Seq.empty, None)
+
+    val accountsWithDDCashAndGuarantee: Accounts = Accounts(
+      Some(AccountWithAuthorities(CdsCashAccount, "12345", Some(AccountStatusOpen), Seq.empty)),
+      Seq("123456"),
+      Some("123456"))
 
     val standingAuthority: StandingAuthority = StandingAuthority("GB123456789012",
       LocalDate.now(), Option(LocalDate.now().plusDays(1)), viewBalance = true)

--- a/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
@@ -171,7 +171,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
       when(mockAuthoritiesCacheService.getAccountAndAuthority(any(), any(), any())(any()))
         .thenReturn(Future.successful(Right(AccountAndAuthority(accountsWithAuthoritiesWithId, standingAuthority))))
 
-      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(),any())(any()))
+      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), any())(any()))
         .thenReturn(Future.successful(false))
 
       running(app) {
@@ -192,7 +192,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
       when(mockAuthoritiesCacheService.getAccountAndAuthority(any(), any(), any())(any()))
         .thenReturn(Future.successful(Right(AccountAndAuthority(accountsWithAuthoritiesWithId, standingAuthority))))
 
-      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(),any())(any()))
+      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), any())(any()))
         .thenReturn(Future.successful(true))
 
       running(app) {

--- a/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
@@ -18,6 +18,7 @@ package controllers.remove
 
 import base.SpecBase
 import connectors.{CustomsDataStoreConnector, CustomsFinancialsConnector}
+import models.UserAnswers
 import models.domain._
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{verify, when}
@@ -204,7 +205,8 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
 
     "redirect to confirmation page and use GB Eori as ownerEori when authorisedEori is XI Eori " +
       "and account type is CdsCashAccount" in new Setup {
-      val userAnswers = emptyUserAnswers.set(RemoveAuthorisedUserPage("a", "b"), AuthorisedUser("test", "test")).get
+      val userAnswers: UserAnswers =
+        emptyUserAnswers.set(RemoveAuthorisedUserPage("a", "b"), AuthorisedUser("test", "test")).get
 
       val app: Application = applicationBuilder(Some(userAnswers), "GB123456789012").overrides(
         inject.bind[AuthoritiesCacheService].toInstance(mockAuthoritiesCacheService),
@@ -235,7 +237,8 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
 
     "redirect to confirmation page and use GB Eori as ownerEori when authorisedEori is XI Eori " +
       "and account type is CdsGeneralGuaranteeAccount" in new Setup {
-      val userAnswers = emptyUserAnswers.set(RemoveAuthorisedUserPage("a", "b"), AuthorisedUser("test", "test")).get
+      val userAnswers: UserAnswers =
+        emptyUserAnswers.set(RemoveAuthorisedUserPage("a", "b"), AuthorisedUser("test", "test")).get
 
       val app: Application = applicationBuilder(Some(userAnswers), "GB123456789012").overrides(
         inject.bind[AuthoritiesCacheService].toInstance(mockAuthoritiesCacheService),
@@ -266,7 +269,8 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
 
     "redirect to confirmation page and use XI Eori as ownerEori when authorisedEori is XI Eori " +
       "and account type is CdsDutyDefermentAccount" in new Setup {
-      val userAnswers = emptyUserAnswers.set(RemoveAuthorisedUserPage("a", "b"), AuthorisedUser("test", "test")).get
+      val userAnswers: UserAnswers =
+        emptyUserAnswers.set(RemoveAuthorisedUserPage("a", "b"), AuthorisedUser("test", "test")).get
 
       val app: Application = applicationBuilder(Some(userAnswers), "GB123456789012").overrides(
         inject.bind[AuthoritiesCacheService].toInstance(mockAuthoritiesCacheService),

--- a/test/models/requests/ManageAuthorityRequestsSpec.scala
+++ b/test/models/requests/ManageAuthorityRequestsSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.requests
+
+import base.SpecBase
+
+class ManageAuthorityRequestsSpec extends SpecBase {
+
+  "Accounts.hasOnlyDutyDefermentsAccount" should {
+    "return true" when {
+      "only dutyDeferments is present" in new Setup {
+        ddAccountsOnly.hasOnlyDutyDefermentsAccount mustBe true
+      }
+    }
+
+    "return false" when {
+      "accounts other than dutyDeferments are present" in new Setup {
+        accounts.hasOnlyDutyDefermentsAccount mustBe false
+      }
+    }
+  }
+
+  "Accounts.isDutyDefermentsAccountEmpty" should {
+    "return true" when {
+      "dutyDeferments account is not present" in new Setup {
+        ddAccountsEmpty.isDutyDefermentsAccountEmpty mustBe true
+      }
+    }
+
+    "return false" when {
+      "dutyDeferments account is present" in new Setup {
+        accounts.isDutyDefermentsAccountEmpty mustBe false
+      }
+    }
+  }
+
+  trait Setup {
+    val ddAccountsOnly: Accounts = Accounts(None, Seq("67890"), None)
+    val ddAccountsEmpty: Accounts = Accounts(Some("12345"), Seq(), None)
+    val accounts: Accounts = Accounts(Some("12345"), Seq("67890"), Some("12345678"))
+  }
+}


### PR DESCRIPTION
Description - Code changes to update the owner EORI as GB Eori for CAN and GAN if authorised EORI is XI

Below has been done as part of this PR

- Add new test class and new tests
- Relevant code changes
- Minor refactoring