### PR TITLE
[MMCA-4597] - Fix 404 error for customs financials api call from Manage authority frontend while viewing an authority

### DIFF
--- a/app/services/AuthoritiesCacheService.scala
+++ b/app/services/AuthoritiesCacheService.scala
@@ -21,7 +21,6 @@ import models.InternalId
 import models.domain.{AccountWithAuthorities, AccountWithAuthoritiesWithId, AuthoritiesWithId, StandingAuthority}
 import repositories.AuthoritiesRepository
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.StringUtils.emptyString
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -61,7 +60,7 @@ class AuthoritiesCacheService @Inject()(repository: AuthoritiesRepository,
                              authorityId: String,
                              accountId: String)
                             (implicit hc: HeaderCarrier): Future[Either[AuthoritiesCacheErrorResponse, AccountAndAuthority]] = {
-    retrieveAuthorities(internalId, Seq(emptyString)).map {
+    retrieveAuthorities(internalId).map {
       accountsWithAuthorities =>
         accountsWithAuthorities.authorities.get(accountId).map {
           account =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 


### PR DESCRIPTION
Description - Code changes to remove Seq of empty eori value while retrieving authorities while viewing and removing the Authority

Below has been done as part of this PR

- add tests
- relevant code changes 