### PR TITLE
MMCA- 4609-4607 - Implement ACC29 call and display company name on Manage your account authorities' page

### DIFF
--- a/app/controllers/ManageAuthoritiesController.scala
+++ b/app/controllers/ManageAuthoritiesController.scala
@@ -66,8 +66,7 @@ class ManageAuthoritiesController @Inject()(override val messagesApi: MessagesAp
         case (Some(authorities), accounts) =>
           Ok(view(ManageAuthoritiesViewModel(
             authorities,
-            accounts,
-            Map("GB9988776655000" -> "test_company", "XI9988776655000" -> "test_company_1"))))
+            accounts)))
         case (None, _) =>
           Ok(noAccountsView())
       }.recover {

--- a/app/controllers/ManageAuthoritiesController.scala
+++ b/app/controllers/ManageAuthoritiesController.scala
@@ -64,7 +64,10 @@ class ManageAuthoritiesController @Inject()(override val messagesApi: MessagesAp
 
       response.map {
         case (Some(authorities), accounts) =>
-          Ok(view(ManageAuthoritiesViewModel(authorities, accounts)))
+          Ok(view(ManageAuthoritiesViewModel(
+            authorities,
+            accounts,
+            Map("GB9988776655000" -> "test_company", "XI9988776655000" -> "test_company_1"))))
         case (None, _) =>
           Ok(noAccountsView())
       }.recover {

--- a/app/repositories/AuthorisedEoriAndCompanyInfoRepository.scala
+++ b/app/repositories/AuthorisedEoriAndCompanyInfoRepository.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import com.mongodb.client.model.Indexes.ascending
+import org.mongodb.scala.model.Filters.equal
+import org.mongodb.scala.model.{IndexModel, IndexOptions, ReplaceOptions}
+import play.api.Configuration
+import play.api.libs.json._
+import uk.gov.hmrc.mongo.play.PlayMongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AuthorisedEoriAndCompanyInfoRepository @Inject()(val mongoComponent: PlayMongoComponent,
+                                                       val config: Configuration)(implicit val ec: ExecutionContext)
+  extends PlayMongoRepository[AuthorisedEoriAndCompanyInfoCacheEntry](
+    collectionName = "auth-eori-company-info-cache",
+    mongoComponent = mongoComponent,
+    domainFormat = AuthorisedEoriAndCompanyInfoCacheEntry.format,
+    indexes = Seq(
+      IndexModel(
+        ascending("lastUpdated"),
+        IndexOptions()
+          .name("auth-eori-company-last-updated-index")
+          .unique(true)
+          .expireAfter(config.get[Int]("mongodb.timeToLiveInSeconds"), TimeUnit.SECONDS)
+      )
+    )
+  ) {
+  def get(id: String): Future[Option[Map[String, String]]] =
+    collection
+      .find(equal("_id", id))
+      .toSingle()
+      .toFutureOption()
+      .map(_.map(_.data))
+
+  def set(id: String, data: Map[String, String]): Future[Boolean] =
+    collection
+      .replaceOne(
+        equal("_id", id),
+        AuthorisedEoriAndCompanyInfoCacheEntry(id, data, LocalDateTime.now()),
+        ReplaceOptions().upsert(true))
+      .toFuture()
+      .map(_.wasAcknowledged())
+
+  def clear(id: String): Future[Boolean] =
+    collection
+      .deleteOne(equal("_id", id))
+      .toFuture()
+      .map(_.wasAcknowledged())
+}
+
+case class AuthorisedEoriAndCompanyInfoCacheEntry(_id: String,
+                                                  data: Map[String, String],
+                                                  lastUpdated: LocalDateTime)
+
+object AuthorisedEoriAndCompanyInfoCacheEntry {
+  implicit val lastUpdatedReads: Reads[LocalDateTime] = MongoJavatimeFormats.localDateTimeReads
+  implicit val lastUpdatedWrites: Writes[LocalDateTime] = MongoJavatimeFormats.localDateTimeWrites
+
+  implicit val format: OFormat[AuthorisedEoriAndCompanyInfoCacheEntry] =
+    Json.format[AuthorisedEoriAndCompanyInfoCacheEntry]
+}

--- a/app/services/AccountsCacheService.scala
+++ b/app/services/AccountsCacheService.scala
@@ -47,9 +47,5 @@ class AccountsCacheService @Inject()(repository: AccountsRepository,
     CDSAccounts(emptyString, mergedAccounts)
   }
 
-  def retrieveAccountsForId(internalId: InternalId)(implicit hc: HeaderCarrier): Future[Option[CDSAccounts]] =
-    {
-      repository.get(internalId.value)
-    }
-
+  def retrieveAccountsForId(id: InternalId): Future[Option[CDSAccounts]] = repository.get(id.value)
 }

--- a/app/services/AccountsCacheService.scala
+++ b/app/services/AccountsCacheService.scala
@@ -47,4 +47,9 @@ class AccountsCacheService @Inject()(repository: AccountsRepository,
     CDSAccounts(emptyString, mergedAccounts)
   }
 
+  def retrieveAccountsForId(internalId: InternalId)(implicit hc: HeaderCarrier): Future[Option[CDSAccounts]] =
+    {
+      repository.get(internalId.value)
+    }
+
 }

--- a/app/services/AuthorisedEoriAndCompanyInfoService.scala
+++ b/app/services/AuthorisedEoriAndCompanyInfoService.scala
@@ -22,8 +22,8 @@ import repositories.AuthorisedEoriAndCompanyInfoRepository
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class AuthorisedEoriAndCompanyInfoService @Inject ()(repository: AuthorisedEoriAndCompanyInfoRepository)
-                                                    (implicit executionContext: ExecutionContext) {
+class AuthorisedEoriAndCompanyInfoService @Inject()(repository: AuthorisedEoriAndCompanyInfoRepository)
+                                                   (implicit executionContext: ExecutionContext) {
 
   def retrieveAuthEorisAndCompanyInfo(internalId: InternalId): Future[Option[Map[String, String]]] = {
     repository.get(internalId.value)

--- a/app/services/AuthorisedEoriAndCompanyInfoService.scala
+++ b/app/services/AuthorisedEoriAndCompanyInfoService.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import models.InternalId
+import repositories.AuthorisedEoriAndCompanyInfoRepository
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthorisedEoriAndCompanyInfoService @Inject ()(repository: AuthorisedEoriAndCompanyInfoRepository)
+                                                    (implicit executionContext: ExecutionContext) {
+
+  def retrieveAuthEorisAndCompanyInfo(internalId: InternalId): Future[Option[Map[String, String]]] = {
+    repository.get(internalId.value)
+  }
+
+  def storeAuthEorisAndCompanyInfo(internalId: InternalId,
+                                   data: Map[String, String]): Future[Boolean] = {
+    repository.set(internalId.value, data)
+  }
+}

--- a/app/services/AuthoritiesCacheService.scala
+++ b/app/services/AuthoritiesCacheService.scala
@@ -56,6 +56,10 @@ class AuthoritiesCacheService @Inject()(repository: AuthoritiesRepository,
     }
   }
 
+  def retrieveAuthoritiesForId(internalId: InternalId): Future[Option[AuthoritiesWithId]] = {
+    repository.get(internalId.value)
+  }
+
   def getAccountAndAuthority(internalId: InternalId,
                              authorityId: String,
                              accountId: String)

--- a/app/services/AuthoritiesCacheService.scala
+++ b/app/services/AuthoritiesCacheService.scala
@@ -56,9 +56,7 @@ class AuthoritiesCacheService @Inject()(repository: AuthoritiesRepository,
     }
   }
 
-  def retrieveAuthoritiesForId(internalId: InternalId): Future[Option[AuthoritiesWithId]] = {
-    repository.get(internalId.value)
-  }
+  def retrieveAuthoritiesForId(id: InternalId): Future[Option[AuthoritiesWithId]] = repository.get(id.value)
 
   def getAccountAndAuthority(internalId: InternalId,
                              authorityId: String,

--- a/app/viewmodels/ManageAuthoritiesTableViewModel.scala
+++ b/app/viewmodels/ManageAuthoritiesTableViewModel.scala
@@ -16,11 +16,8 @@
 
 package viewmodels
 
-import models.domain.{
-  AccountNumber, AccountStatusClosed, AccountStatusPending, AccountStatusSuspended, AccountType,
-  AccountWithAuthoritiesWithId, CDSAccountStatus, CdsDutyDefermentAccount, StandingAuthority
-}
-
+import models.domain.{AccountNumber, AccountStatusClosed, AccountStatusPending, AccountStatusSuspended, AccountType,
+  AccountWithAuthoritiesWithId, CDSAccountStatus, CdsDutyDefermentAccount, StandingAuthority}
 import play.api.i18n.Messages
 import play.api.mvc.Call
 import utils.DateUtils
@@ -48,6 +45,7 @@ case class AuthorityRowColumnViewModel(hiddenHeadingMsg: String,
                                        spanClassValue: String = "hmrc-responsive-table__heading")
 
 case class AuthorityRowViewModel(authorisedEori: AuthorityRowColumnViewModel,
+                                 companyName: Option[AuthorityRowColumnViewModel] = None,
                                  formattedFromDate: AuthorityRowColumnViewModel,
                                  formattedToDate: AuthorityRowColumnViewModel,
                                  viewBalanceAsString: AuthorityRowColumnViewModel,
@@ -61,7 +59,9 @@ case class ManageAuthoritiesTableViewModel(idString: String,
 object ManageAuthoritiesTableViewModel extends DateUtils {
   def apply(accountId: String,
             account: AccountWithAuthoritiesWithId,
-            isNiAccount: Boolean = false)(implicit messages: Messages): ManageAuthoritiesTableViewModel = {
+            isNiAccount: Boolean = false,
+            authorisedEoriAndCompanyMap: Map[String, String] = Map.empty)
+           (implicit messages: Messages): ManageAuthoritiesTableViewModel = {
 
     val idString = s"${account.accountType}-${account.accountNumber}"
 
@@ -74,7 +74,7 @@ object ManageAuthoritiesTableViewModel extends DateUtils {
       idString,
       accountHeadingMsg,
       authorityHeaderRowViewModel(account),
-      prepareAuthRowsView(accountId, account)
+      prepareAuthRowsView(accountId, account, authorisedEoriAndCompanyMap)
     )
   }
 
@@ -114,7 +114,8 @@ object ManageAuthoritiesTableViewModel extends DateUtils {
     )
 
   private def prepareAuthRowsView(accountId: String,
-                                  account: AccountWithAuthoritiesWithId)
+                                  account: AccountWithAuthoritiesWithId,
+                                  authorisedEoriAndCompanyMap: Map[String, String] = Map.empty)
                                  (implicit messages: Messages): Seq[AuthorityRowViewModel] = {
 
     val sortedAuthorities: ListMap[String, StandingAuthority] =
@@ -126,6 +127,12 @@ object ManageAuthoritiesTableViewModel extends DateUtils {
       AuthorityRowViewModel(
         authorisedEori =
           AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authority.authorisedEori),
+        companyName =
+        if(authorisedEoriAndCompanyMap.contains(authority.authorisedEori)) {
+          Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authorisedEoriAndCompanyMap(authority.authorisedEori)))
+        } else {
+          None
+        },
         formattedFromDate =
           AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.startDate"),
             dateAsdMMMyyyy(authority.authorisedFromDate)),

--- a/app/viewmodels/ManageAuthoritiesTableViewModel.scala
+++ b/app/viewmodels/ManageAuthoritiesTableViewModel.scala
@@ -115,7 +115,7 @@ object ManageAuthoritiesTableViewModel extends DateUtils {
 
   private def prepareAuthRowsView(accountId: String,
                                   account: AccountWithAuthoritiesWithId,
-                                  authorisedEoriAndCompanyMap: Map[String, String] = Map.empty)
+                                  authorisedEoriAndCompanyMap: Map[String, String])
                                  (implicit messages: Messages): Seq[AuthorityRowViewModel] = {
 
     val sortedAuthorities: ListMap[String, StandingAuthority] =

--- a/app/viewmodels/ManageAuthoritiesTableViewModel.scala
+++ b/app/viewmodels/ManageAuthoritiesTableViewModel.scala
@@ -128,11 +128,12 @@ object ManageAuthoritiesTableViewModel extends DateUtils {
         authorisedEori =
           AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authority.authorisedEori),
         companyName =
-        if(authorisedEoriAndCompanyMap.contains(authority.authorisedEori)) {
-          Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authorisedEoriAndCompanyMap(authority.authorisedEori)))
-        } else {
-          None
-        },
+          if (authorisedEoriAndCompanyMap.contains(authority.authorisedEori)) {
+            Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"),
+              authorisedEoriAndCompanyMap(authority.authorisedEori)))
+          } else {
+            None
+          },
         formattedFromDate =
           AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.startDate"),
             dateAsdMMMyyyy(authority.authorisedFromDate)),

--- a/app/viewmodels/ManageAuthoritiesViewModel.scala
+++ b/app/viewmodels/ManageAuthoritiesViewModel.scala
@@ -24,7 +24,9 @@ import java.time.LocalDate
 import java.time.chrono.ChronoLocalDate
 import scala.collection.immutable.ListMap
 
-case class ManageAuthoritiesViewModel(authorities: AuthoritiesWithId, accounts: CDSAccounts) {
+case class ManageAuthoritiesViewModel(authorities: AuthoritiesWithId,
+                                      accounts: CDSAccounts,
+                                      auhorisedEoriAndCompanyMap: Map[String, String] = Map.empty) {
 
   def hasAccounts: Boolean = authorities.accounts.nonEmpty
 

--- a/app/views/ManageAuthoritiesView.scala.html
+++ b/app/views/ManageAuthoritiesView.scala.html
@@ -67,7 +67,11 @@
         <div id="accounts-with-authorities" class="govuk-!-margin-bottom-6 govuk-!-padding-top-3">
             @for((id, account) <- viewModel.sortedAccounts) {
                 @manageAuthoritiesTable(
-                    ManageAuthoritiesTableViewModel(id, account, viewModel.niIndicator(account.accountNumber))
+                    ManageAuthoritiesTableViewModel(
+                        id,
+                        account,
+                        viewModel.niIndicator(account.accountNumber),
+                        viewModel.auhorisedEoriAndCompanyMap)
                 )
             }
         </div>

--- a/app/views/partials/ManageAuthoritiesTable.scala.html
+++ b/app/views/partials/ManageAuthoritiesTable.scala.html
@@ -25,10 +25,10 @@
 
 <div id="@model.idString" class="account-with-authorities">
     <table class="govuk-table hmrc-responsive-table govuk-!-margin-bottom-9">
-        <caption id="@model.idString-heading" class="govuk-table__caption">
+        <caption id="@model.idString-heading" class="govuk-table__caption govuk-table__cell">
             @model.accountHeadingMsg
         </caption>
-        <thead class="govuk-table__head">
+        <!--<thead class="govuk-table__head">
             <tr class="govuk-table__row">
                 <th id="@model.authHeaderRowViewModel.authCompanyId" scope="col"
                     class="govuk-table__header govuk-!-width-one-quarter">
@@ -49,7 +49,7 @@
                     </span>
                 </th>
             </tr>
-        </thead>
+        </thead>-->
         <tbody class="govuk-table__body">
             @for(authRowModel <- model.authRows) {
                 <tr class="govuk-table__row">
@@ -66,7 +66,7 @@
                             @companyModel.displayValue
                         }
                     </td>
-                    <td class="@authRowModel.formattedFromDate.classValue">
+                    <!--<td class="@authRowModel.formattedFromDate.classValue">
                         <span class="@authRowModel.formattedFromDate.spanClassValue" aria-hidden="true">
                             @authRowModel.formattedFromDate.hiddenHeadingMsg
                         </span>
@@ -83,7 +83,7 @@
                             @authRowModel.viewBalanceAsString.hiddenHeadingMsg
                         </span>
                         @authRowModel.viewBalanceAsString.displayValue
-                    </td>
+                    </td>-->
                     <td class="@authRowModel.viewLink.classValue">
                         @if(authRowModel.viewLink.isAccountStatusNonClosed) {
                             <a class="govuk-link" href="@authRowModel.viewLink.href.getOrElse(emptyString)">

--- a/app/views/partials/ManageAuthoritiesTable.scala.html
+++ b/app/views/partials/ManageAuthoritiesTable.scala.html
@@ -58,6 +58,13 @@
                             @authRowModel.authorisedEori.hiddenHeadingMsg
                         </span>
                         @authRowModel.authorisedEori.displayValue
+                        <br/>
+                        @authRowModel.companyName.map { companyModel =>
+                            <span class="@companyModel.spanClassValue" aria-hidden="true">
+                                @companyModel.hiddenHeadingMsg
+                            </span>
+                            @companyModel.displayValue
+                        }
                     </td>
                     <td class="@authRowModel.formattedFromDate.classValue">
                         <span class="@authRowModel.formattedFromDate.spanClassValue" aria-hidden="true">

--- a/app/views/partials/ManageAuthoritiesTable.scala.html
+++ b/app/views/partials/ManageAuthoritiesTable.scala.html
@@ -28,28 +28,6 @@
         <caption id="@model.idString-heading" class="govuk-table__caption govuk-table__cell">
             @model.accountHeadingMsg
         </caption>
-        <!--<thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-                <th id="@model.authHeaderRowViewModel.authCompanyId" scope="col"
-                    class="govuk-table__header govuk-!-width-one-quarter">
-                    @model.authHeaderRowViewModel.authCompanyHeaderValue
-                </th>
-                <th id="@model.authHeaderRowViewModel.startDateId" scope="col" class="govuk-table__header">
-                    @model.authHeaderRowViewModel.startDateHeader
-                </th>
-                <th id="@model.authHeaderRowViewModel.endDateId" scope="col" class="govuk-table__header">
-                    @model.authHeaderRowViewModel.endDateHeader
-                </th>
-                <th id="@model.authHeaderRowViewModel.viewBalanceId" scope="col" class="govuk-table__header">
-                    @model.authHeaderRowViewModel.viewBalanceHeaderValue
-                </th>
-                <th id="@model.authHeaderRowViewModel.hiddenActionsId" scope="col" class="govuk-table__header">
-                    <span class="govuk-visually-hidden">
-                        @model.authHeaderRowViewModel.hiddenActionsHeaderValue
-                    </span>
-                </th>
-            </tr>
-        </thead>-->
         <tbody class="govuk-table__body">
             @for(authRowModel <- model.authRows) {
                 <tr class="govuk-table__row">
@@ -66,24 +44,6 @@
                             @companyModel.displayValue
                         }
                     </td>
-                    <!--<td class="@authRowModel.formattedFromDate.classValue">
-                        <span class="@authRowModel.formattedFromDate.spanClassValue" aria-hidden="true">
-                            @authRowModel.formattedFromDate.hiddenHeadingMsg
-                        </span>
-                        @authRowModel.formattedFromDate.displayValue
-                    </td>
-                    <td class="@authRowModel.formattedToDate.classValue">
-                        <span class="@authRowModel.formattedToDate.spanClassValue" aria-hidden="true">
-                            @authRowModel.formattedToDate.hiddenHeadingMsg
-                        </span>
-                            @authRowModel.formattedToDate.displayValue
-                    </td>
-                    <td class="@authRowModel.viewBalanceAsString.classValue">
-                        <span class="@authRowModel.viewBalanceAsString.spanClassValue" aria-hidden="true">
-                            @authRowModel.viewBalanceAsString.hiddenHeadingMsg
-                        </span>
-                        @authRowModel.viewBalanceAsString.displayValue
-                    </td>-->
                     <td class="@authRowModel.viewLink.classValue">
                         @if(authRowModel.viewLink.isAccountStatusNonClosed) {
                             <a class="govuk-link" href="@authRowModel.viewLink.href.getOrElse(emptyString)">

--- a/test/controllers/ManageAuthoritiesControllerSpec.scala
+++ b/test/controllers/ManageAuthoritiesControllerSpec.scala
@@ -19,7 +19,8 @@ package controllers
 import base.SpecBase
 import config.FrontendAppConfig
 import connectors.{CustomsDataStoreConnector, CustomsFinancialsConnector}
-import models.domain.{AccountStatusClosed, AccountStatusOpen, AccountStatusPending, AccountWithAuthoritiesWithId, AuthoritiesWithId, CDSAccounts, CDSCashBalance, CashAccount, CdsCashAccount, StandingAuthority}
+import models.domain.{AccountStatusClosed, AccountStatusOpen, AccountStatusPending, AccountWithAuthoritiesWithId,
+  AuthoritiesWithId, CDSAccounts, CDSCashBalance, CashAccount, CdsCashAccount, StandingAuthority}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
@@ -90,7 +91,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
         val mockAccountsCacheService = mock[AccountsCacheService]
         val mockAuthCacheService = mock[AuthoritiesCacheService]
         val mockDataStoreConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
-        //val mockAuthEoriAndCompanyService = mock[AuthorisedEoriAndCompanyInfoService]
+        val mockAuthEoriAndCompanyService = mock[AuthorisedEoriAndCompanyInfoService]
 
         when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future.successful(Some(XI_EORI)))
         when(mockDataStoreConnector.getEmail(any)(any)).thenReturn(Future.successful(Right(testEmail)))
@@ -99,8 +100,8 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
         when(mockRepository.get(any())).thenReturn(Future.successful(Some(authoritiesWithId)))
         when(mockAuthCacheService.retrieveAuthorities(any, any)(any)).thenReturn(Future.successful(authoritiesWithId))
         when(mockAccountsCacheService.retrieveAccounts(any(), any())(any())).thenReturn(Future.successful(accounts))
-        /*when(mockAuthEoriAndCompanyService.retrieveAuthorisedEoriAndCompanyInfo(any, any)(any))
-          .thenReturn(Future.successful(Some(eoriAndCompanyInfoMap)))*/
+        when(mockAuthEoriAndCompanyService.retrieveAuthorisedEoriAndCompanyInfo(any, any)(any))
+          .thenReturn(Future.successful(Some(eoriAndCompanyInfoMap)))
 
         val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(

--- a/test/services/AccountsCacheServiceSpec.scala
+++ b/test/services/AccountsCacheServiceSpec.scala
@@ -23,8 +23,10 @@ import models.domain._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar._
+import play.api.Application
 import repositories.AccountsRepository
 import uk.gov.hmrc.http.HeaderCarrier
+
 import scala.concurrent.Future
 import utils.StringUtils.emptyString
 
@@ -78,35 +80,61 @@ class AccountsCacheServiceSpec extends SpecBase {
       res mustBe compare
     }
   }
-}
 
-trait Setup {
+  "retrieveAuthoritiesForId" must {
 
-  val notCachedAccounts: CDSAccounts = CDSAccounts("GB123456789012",
-    List(CashAccount("12345", "GB123456789012", AccountStatusOpen, CDSCashBalance(Some(100.00)))))
+    "return return the authorities for the given InternalId" in new Setup {
+      when(mockRepository.get("cachedId")).thenReturn(Future.successful(Some(cachedAuthorities)))
 
-  val cachedAccounts: CDSAccounts = CDSAccounts("GB098765432109",
-    List(CashAccount("54321", "GB098765432109", AccountStatusOpen, CDSCashBalance(Some(100.00)))))
+      when(mockRepository.set(any(), any())).thenReturn(Future.successful(true))
 
-  val closedAccount: CDSAccounts = CDSAccounts("GB098765432109",
-    List(CashAccount("54321", "GB098765432109", AccountStatusClosed, CDSCashBalance(Some(100.00)))))
+      val result: Future[Option[AuthoritiesWithId]] = authCacheServices.retrieveAuthoritiesForId(InternalId("cachedId"))
 
-  val suspendedAccount: CDSAccounts = CDSAccounts("GB098765432109",
-    List(CashAccount("54321", "GB098765432109", AccountStatusSuspended, CDSCashBalance(Some(100.00)))))
+      result.map {
+        authorities => authorities mustBe Some(InternalId("cachedId"))
+      }
+    }
+  }
 
-  val pendingAccount: CDSAccounts = CDSAccounts("GB098765432109",
-    List(CashAccount("54321", "GB098765432109", AccountStatusPending, CDSCashBalance(Some(100.00)))))
+  trait Setup {
 
-  implicit lazy val hc: HeaderCarrier = HeaderCarrier()
-  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+    val notCachedAccounts: CDSAccounts = CDSAccounts("GB123456789012",
+      List(CashAccount("12345", "GB123456789012", AccountStatusOpen, CDSCashBalance(Some(100.00)))))
 
-  var mockRepository: AccountsRepository = mock[AccountsRepository]
+    val cachedAccounts: CDSAccounts = CDSAccounts("GB098765432109",
+      List(CashAccount("54321", "GB098765432109", AccountStatusOpen, CDSCashBalance(Some(100.00)))))
 
-  when(mockRepository.get("cachedId")).thenReturn(Future.successful(Some(cachedAccounts)))
-  when(mockRepository.get("notCachedId")).thenReturn(Future.successful(None))
-  when(mockRepository.set(any(), any())).thenReturn(Future.successful(true))
+    val closedAccount: CDSAccounts = CDSAccounts("GB098765432109",
+      List(CashAccount("54321", "GB098765432109", AccountStatusClosed, CDSCashBalance(Some(100.00)))))
 
-  val mockConnector: CustomsFinancialsConnector = mock[CustomsFinancialsConnector]
+    val suspendedAccount: CDSAccounts = CDSAccounts("GB098765432109",
+      List(CashAccount("54321", "GB098765432109", AccountStatusSuspended, CDSCashBalance(Some(100.00)))))
 
-  when(mockConnector.retrieveAccounts(any())(any())).thenReturn(Future.successful(notCachedAccounts))
+    val pendingAccount: CDSAccounts = CDSAccounts("GB098765432109",
+      List(CashAccount("54321", "GB098765432109", AccountStatusPending, CDSCashBalance(Some(100.00)))))
+
+    implicit lazy val hc: HeaderCarrier = HeaderCarrier()
+    implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+    var mockRepository: AccountsRepository = mock[AccountsRepository]
+
+    when(mockRepository.get("cachedId")).thenReturn(Future.successful(Some(cachedAccounts)))
+    when(mockRepository.get("notCachedId")).thenReturn(Future.successful(None))
+    when(mockRepository.set(any(), any())).thenReturn(Future.successful(true))
+
+    val mockConnector: CustomsFinancialsConnector = mock[CustomsFinancialsConnector]
+
+    when(mockConnector.retrieveAccounts(any())(any())).thenReturn(Future.successful(notCachedAccounts))
+
+    val mockConnector: CustomsFinancialsConnector = mock[CustomsFinancialsConnector]
+    val mockAccountsCacheService: AccountsCacheService = mock[AccountsCacheService]
+
+ /*   val app: Application = applicationBuilder().overrides(
+      inject.bind[CustomsFinancialsConnector].toInstance(mockConnector),
+      inject.bind[AuthoritiesRepository].toInstance(mockAuthRepo)
+    ).build()*/
+
+    val authCacheServices: AuthoritiesCacheService = app.injector.instanceOf[AuthoritiesCacheService]
+  }
+
 }

--- a/test/services/AuthorisedEoriAndCompanyInfoServiceSpec.scala
+++ b/test/services/AuthorisedEoriAndCompanyInfoServiceSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import base.SpecBase
+import models.InternalId
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.{Application, inject}
+import repositories.AuthorisedEoriAndCompanyInfoRepository
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class AuthorisedEoriAndCompanyInfoServiceSpec extends SpecBase {
+
+  "retrieveAuthEorisAndCompanyInfo" must {
+
+    "retrieve the data correctly" in new Setup {
+      when(mockRepo.get(id.value)).thenReturn(Future.successful(Some(data)))
+
+      service.retrieveAuthEorisAndCompanyInfo(id).map {
+        result => result mustEqual data
+      }
+    }
+  }
+
+  "storeAuthEorisAndCompanyInfo" must {
+
+    "successfully store the data" in new Setup {
+      when(mockRepo.set(id.value, data)).thenReturn(Future.successful(true))
+
+      service.storeAuthEorisAndCompanyInfo(id, data).map {
+        result => result mustEqual true
+      }
+    }
+  }
+
+  trait Setup {
+    val id: InternalId = InternalId("cache_id")
+    val data: Map[String, String] = Map("eori_1" -> "company_1", "eori_2" -> "company_2")
+
+    val mockRepo: AuthorisedEoriAndCompanyInfoRepository = mock[AuthorisedEoriAndCompanyInfoRepository]
+
+    val application: Application = applicationBuilder().overrides(
+      inject.bind[AuthorisedEoriAndCompanyInfoRepository].toInstance(mockRepo)
+    ).build()
+
+    val service: AuthorisedEoriAndCompanyInfoService =
+      application.injector.instanceOf[AuthorisedEoriAndCompanyInfoService]
+  }
+}

--- a/test/services/AuthorisedEoriAndCompanyInfoServiceSpec.scala
+++ b/test/services/AuthorisedEoriAndCompanyInfoServiceSpec.scala
@@ -17,24 +17,62 @@
 package services
 
 import base.SpecBase
+import connectors.CustomsDataStoreConnector
 import models.InternalId
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.{Application, inject}
 import repositories.AuthorisedEoriAndCompanyInfoRepository
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.TestData.COMPANY_NAME
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class AuthorisedEoriAndCompanyInfoServiceSpec extends SpecBase {
 
-  "retrieveAuthEorisAndCompanyInfo" must {
+  "retrieveAuthEorisAndCompanyInfoForId" must {
 
     "retrieve the data correctly" in new Setup {
       when(mockRepo.get(id.value)).thenReturn(Future.successful(Some(data)))
 
-      service.retrieveAuthEorisAndCompanyInfo(id).map {
+      service.retrieveAuthEorisAndCompanyInfoForId(id).map {
         result => result mustEqual data
+      }
+    }
+  }
+
+  "retrieveAuthorisedEoriAndCompanyInfo" must {
+
+    "retrieve the data correctly" when {
+
+      "data is not present in cache" in new Setup {
+        val eoris: Set[String] = Set(eori1, eori2)
+        val mapData: Map[String, String] = Map(eori1 -> COMPANY_NAME, eori2 -> COMPANY_NAME)
+
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+
+        when(mockRepo.get(id.value)).thenReturn(Future.successful(None))
+        when(mockRepo.set(id.value, mapData)).thenReturn(Future.successful(true))
+        when(mockDataStoreConnector.getCompanyName(any)(any)).thenReturn(Future.successful(Some(COMPANY_NAME)))
+
+        service.retrieveAuthorisedEoriAndCompanyInfo(id, eoris).map {
+          result => result mustEqual mapData
+        }
+      }
+
+      "data is present in cache" in new Setup {
+        val eoris: Set[String] = Set(eori1, eori2)
+        val mapData: Map[String, String] = Map(eori1 -> COMPANY_NAME, eori2 -> COMPANY_NAME)
+
+        implicit val hc: HeaderCarrier = HeaderCarrier()
+
+        when(mockRepo.get(id.value)).thenReturn(Future.successful(Some(mapData)))
+
+        service.retrieveAuthorisedEoriAndCompanyInfo(id, eoris).map {
+          result => result mustEqual mapData
+        }
       }
     }
   }
@@ -52,12 +90,16 @@ class AuthorisedEoriAndCompanyInfoServiceSpec extends SpecBase {
 
   trait Setup {
     val id: InternalId = InternalId("cache_id")
+    val eori1 = "test_eori_1"
+    val eori2 = "test_eori_2"
     val data: Map[String, String] = Map("eori_1" -> "company_1", "eori_2" -> "company_2")
 
     val mockRepo: AuthorisedEoriAndCompanyInfoRepository = mock[AuthorisedEoriAndCompanyInfoRepository]
+    val mockDataStoreConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
 
     val application: Application = applicationBuilder().overrides(
-      inject.bind[AuthorisedEoriAndCompanyInfoRepository].toInstance(mockRepo)
+      inject.bind[AuthorisedEoriAndCompanyInfoRepository].toInstance(mockRepo),
+      inject.bind[CustomsDataStoreConnector].toInstance(mockDataStoreConnector)
     ).build()
 
     val service: AuthorisedEoriAndCompanyInfoService =

--- a/test/services/AuthoritiesCacheServiceSpec.scala
+++ b/test/services/AuthoritiesCacheServiceSpec.scala
@@ -106,6 +106,21 @@ class AuthoritiesCacheServiceSpec extends SpecBase {
     }
   }
 
+  "retrieveAuthoritiesForId" must {
+
+    "return return the authorities for the given InternalId" in new Setup {
+      when(mockAuthRepo.get("cachedId")).thenReturn(Future.successful(Some(cachedAuthorities)))
+
+      when(mockAuthRepo.set(any(), any())).thenReturn(Future.successful(true))
+
+      val result: Future[Option[AuthoritiesWithId]] = authCacheServices.retrieveAuthoritiesForId(InternalId("cachedId"))
+
+      result.map {
+        authorities => authorities mustBe Some(InternalId("cachedId"))
+      }
+    }
+  }
+
   trait Setup {
     implicit lazy val hc: HeaderCarrier = HeaderCarrier()
     implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -34,6 +34,7 @@ object TestData {
   val ACCOUNT_NUMBER = "12345678"
   val EORI_NUMBER = "EORI"
   val XI_EORI = "XI12345678"
+  val COMPANY_NAME = "test_company"
 
   val testEmail: Email = Email("test_address")
 

--- a/test/viewmodels/ManageAuthoritiesTableViewModelSpec.scala
+++ b/test/viewmodels/ManageAuthoritiesTableViewModelSpec.scala
@@ -113,7 +113,20 @@ class ManageAuthoritiesTableViewModelSpec extends ViewTestHelper {
       "account status is closed" in {
         val viewModelOb = ManageAuthoritiesTableViewModel(ACCOUNT_ID, CLOSED_GG_ACC_WITH_AUTH_WITH_ID)
 
-        val expectedAuthRowsView: Seq[AuthorityRowViewModel] = authRowViewModelForClosedAccount
+        val expectedAuthRowsView: Seq[AuthorityRowViewModel] = authRowViewModelForClosedAccount()
+
+        viewModelOb.authRows mustBe expectedAuthRowsView
+      }
+
+      "authorisedEoriAndCompanyMap in not empty" in {
+        val authEorisAndCompanyMap = Map(EORI_NUMBER -> "test_company")
+        val viewModelOb = ManageAuthoritiesTableViewModel(
+          ACCOUNT_ID,
+          CLOSED_GG_ACC_WITH_AUTH_WITH_ID,
+          isNiAccount = false,
+          authEorisAndCompanyMap)
+
+        val expectedAuthRowsView: Seq[AuthorityRowViewModel] = authRowViewModelForClosedAccount(authEorisAndCompanyMap)
 
         viewModelOb.authRows mustBe expectedAuthRowsView
       }
@@ -186,10 +199,16 @@ class ManageAuthoritiesTableViewModelSpec extends ViewTestHelper {
     )
   }
 
-  private def authRowViewModelForClosedAccount: Seq[AuthorityRowViewModel] = {
+  private def authRowViewModelForClosedAccount(authEoriAndCompanyMap: Map[String, String] = Map.empty
+                                              ): Seq[AuthorityRowViewModel] = {
     Seq(
       AuthorityRowViewModel(
         authorisedEori = AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), EORI_NUMBER),
+
+        companyName =
+          if(authEoriAndCompanyMap.contains(EORI_NUMBER)) {
+            Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authEoriAndCompanyMap(EORI_NUMBER)))
+          } else None,
 
         formattedFromDate = AuthorityRowColumnViewModel(
           messages("manageAuthorities.table.heading.startDate"),
@@ -214,6 +233,11 @@ class ManageAuthoritiesTableViewModelSpec extends ViewTestHelper {
       ),
       AuthorityRowViewModel(
         authorisedEori = AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), EORI_NUMBER),
+
+        companyName =
+          if (authEoriAndCompanyMap.contains(EORI_NUMBER)) {
+            Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authEoriAndCompanyMap(EORI_NUMBER)))
+          } else None,
 
         formattedFromDate = AuthorityRowColumnViewModel(
           messages("manageAuthorities.table.heading.startDate"),

--- a/test/viewmodels/ManageAuthoritiesTableViewModelSpec.scala
+++ b/test/viewmodels/ManageAuthoritiesTableViewModelSpec.scala
@@ -208,7 +208,7 @@ class ManageAuthoritiesTableViewModelSpec extends ViewTestHelper {
         companyName =
           if(authEoriAndCompanyMap.contains(EORI_NUMBER)) {
             Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authEoriAndCompanyMap(EORI_NUMBER)))
-          } else None,
+          } else { None },
 
         formattedFromDate = AuthorityRowColumnViewModel(
           messages("manageAuthorities.table.heading.startDate"),
@@ -237,7 +237,7 @@ class ManageAuthoritiesTableViewModelSpec extends ViewTestHelper {
         companyName =
           if (authEoriAndCompanyMap.contains(EORI_NUMBER)) {
             Some(AuthorityRowColumnViewModel(messages("manageAuthorities.table.heading.user"), authEoriAndCompanyMap(EORI_NUMBER)))
-          } else None,
+          } else { None },
 
         formattedFromDate = AuthorityRowColumnViewModel(
           messages("manageAuthorities.table.heading.startDate"),

--- a/test/viewmodels/ManageAuthoritiesViewModelSpec.scala
+++ b/test/viewmodels/ManageAuthoritiesViewModelSpec.scala
@@ -31,17 +31,17 @@ class ManageAuthoritiesViewModelSpec extends SpecBase {
     )
   )
 
-  val startDate = LocalDate.parse("2020-03-01")
-  val endDate = LocalDate.parse("2020-04-01")
+  val startDate: LocalDate = LocalDate.parse("2020-03-01")
+  val endDate: LocalDate = LocalDate.parse("2020-04-01")
 
-  val standingAuthorityWithView = StandingAuthority(
+  val standingAuthorityWithView: StandingAuthority = StandingAuthority(
     "EORI1",
     LocalDate.parse("2020-03-01"),
     Some(LocalDate.parse("2020-04-01")),
     viewBalance = true
   )
 
-  val standingAuthorityWithoutView = StandingAuthority(
+  val standingAuthorityWithoutView: StandingAuthority = StandingAuthority(
     "EORI2",
     LocalDate.parse("2020-02-01"),
     None,
@@ -101,6 +101,18 @@ class ManageAuthoritiesViewModelSpec extends SpecBase {
 
       val viewModel = ManageAuthoritiesViewModel(authorities, cdsAccounts)
       viewModel.sortedAccounts.keys.toSeq mustBe Seq("d", "c", "a", "b")
+    }
+
+    "return correct value of authorisedEoriAndCompany map" in {
+      val authEoriAndCompanyDetails = Map("test_eori_1" -> "company_1", "test_eori_2" -> "company_2")
+
+      val cdsAccounts = CDSAccounts("GB123456789012", List(
+        CashAccount("12345", "GB123456789012", AccountStatusOpen, CDSCashBalance(Some(100.00))),
+        CashAccount("23456", "GB123456789012", AccountStatusClosed, CDSCashBalance(Some(100.00)))
+      ))
+
+      val viewModel = ManageAuthoritiesViewModel(authorities, cdsAccounts, authEoriAndCompanyDetails)
+      viewModel.auhorisedEoriAndCompanyMap mustBe authEoriAndCompanyDetails
     }
   }
 }

--- a/test/views/partials/ManageAuthoritiesTableSpec.scala
+++ b/test/views/partials/ManageAuthoritiesTableSpec.scala
@@ -37,7 +37,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
         val view = viewAsDoc(ACCOUNT_ID, OPEN_CASH_ACC_WITH_AUTH_WITH_ID, isNiAccount = false, authEoriAndCompanyMap)
 
         shouldContainCorrectAccountStatusMsgForStatusOpen(view, OPEN_CASH_ACC_WITH_AUTH_WITH_ID)
-        shouldContainCorrectHeaderValues(view, OPEN_CASH_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectElementValuesForAuthorityRows(view, OPEN_CASH_ACC_WITH_AUTH_WITH_ID)
       }
 
@@ -45,7 +44,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
         val view = viewAsDoc(ACCOUNT_ID, CLOSED_CASH_ACC_WITH_AUTH_WITH_ID)
 
         shouldContainCorrectAccountStatusMsgForStatusClosed(view, CLOSED_CASH_ACC_WITH_AUTH_WITH_ID)
-        shouldContainCorrectHeaderValues(view, CLOSED_CASH_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectElementValuesForAuthorityRows(view, CLOSED_CASH_ACC_WITH_AUTH_WITH_ID)
       }
 
@@ -53,7 +51,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
         val view = viewAsDoc(ACCOUNT_ID, SUSPENDED_CASH_ACC_WITH_AUTH_WITH_ID)
 
         shouldContainCorrectAccountStatusMsgForStatusSuspended(view, SUSPENDED_CASH_ACC_WITH_AUTH_WITH_ID)
-        shouldContainCorrectHeaderValues(view, SUSPENDED_CASH_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectElementValuesForAuthorityRows(view, SUSPENDED_CASH_ACC_WITH_AUTH_WITH_ID)
       }
 
@@ -61,7 +58,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
         val view = viewAsDoc(ACCOUNT_ID, PENDING_CASH_ACC_WITH_AUTH_WITH_ID)
 
         shouldContainCorrectAccountStatusMsgForStatusPending(view, PENDING_CASH_ACC_WITH_AUTH_WITH_ID)
-        shouldContainCorrectHeaderValues(view, PENDING_CASH_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectElementValuesForAuthorityRows(view, PENDING_CASH_ACC_WITH_AUTH_WITH_ID)
       }
 
@@ -69,7 +65,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
         val view = viewAsDoc(ACCOUNT_ID, NONE_DD_ACC_WITH_AUTH_WITH_ID)
 
         shouldContainCorrectAccountStatusMsgForStatusNone(view, NONE_DD_ACC_WITH_AUTH_WITH_ID)
-        shouldContainCorrectHeaderValues(view, NONE_DD_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectElementValuesForAuthorityRows(view, NONE_DD_ACC_WITH_AUTH_WITH_ID)
       }
 
@@ -77,7 +72,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
         val view = viewAsDoc(ACCOUNT_ID, OPEN_DD_ACC_WITH_AUTH_WITH_ID)
 
         shouldContainCorrectAccountStatusMsgForDDNonNIAccount(view, OPEN_DD_ACC_WITH_AUTH_WITH_ID)
-        shouldContainCorrectHeaderValues(view, OPEN_DD_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectElementValuesForAuthorityRows(view, OPEN_DD_ACC_WITH_AUTH_WITH_ID)
       }
     }
@@ -133,34 +127,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
     }-${account.accountNumber}-heading").text() mustBe
       messages(s"manageAuthorities.table.heading.account.${account.accountType}", account.accountNumber)
 
-  private def shouldContainCorrectHeaderValues(view: Document,
-                                               account: AccountWithAuthoritiesWithId): Assertion = {
-    view.getElementById(
-      s"account-authorities-table-user-heading-${
-        account.accountType
-      }-${account.accountNumber}").text() mustBe messages("manageAuthorities.table.heading.user")
-
-    view.getElementById(
-      s"account-authorities-table-start-date-heading-${
-        account.accountType
-      }-${account.accountNumber}").text() mustBe messages("manageAuthorities.table.heading.startDate")
-
-    view.getElementById(
-      s"account-authorities-table-end-date-heading-${
-        account.accountType
-      }-${account.accountNumber}").text() mustBe messages("manageAuthorities.table.heading.endDate")
-
-    view.getElementById(
-      s"account-authorities-table-view-balance-heading-${
-        account.accountType
-      }-${account.accountNumber}").text() mustBe messages("manageAuthorities.table.heading.balance")
-
-    view.getElementById(
-      s"account-authorities-table-actions-heading-${
-        account.accountType
-      }-${account.accountNumber}").text() mustBe messages("manageAuthorities.table.heading.actions")
-  }
-
   private def shouldContainCorrectElementValuesForAuthorityRows(view: Document,
                                                                 account: AccountWithAuthoritiesWithId,
                                                                 authEoriAndCompanyMap: Map[String, String] = Map.empty): Assertion = {
@@ -172,9 +138,6 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
     if(authEoriAndCompanyMap.contains(EORI_NUMBER)) {
       tableRowHtml.contains(messages("manageAuthorities.table.heading.user")) mustBe true
     }
-    tableRowHtml.contains(messages("manageAuthorities.table.heading.startDate")) mustBe true
-    tableRowHtml.contains(messages("manageAuthorities.table.heading.endDate")) mustBe true
-    tableRowHtml.contains(messages("manageAuthorities.table.heading.balance")) mustBe true
 
     if (account.accountStatus.fold(true)(status => status != AccountStatusClosed)) {
       tableRowHtml.contains(messages("manageAuthorities.table.view-or-change")) mustBe true

--- a/test/views/partials/ManageAuthoritiesTableSpec.scala
+++ b/test/views/partials/ManageAuthoritiesTableSpec.scala
@@ -32,7 +32,9 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
     "display correct text and guidance" when {
 
       "account status is open" in {
-        val view = viewAsDoc(ACCOUNT_ID, OPEN_CASH_ACC_WITH_AUTH_WITH_ID)
+        val authEoriAndCompanyMap = Map(EORI_NUMBER -> "test_company")
+
+        val view = viewAsDoc(ACCOUNT_ID, OPEN_CASH_ACC_WITH_AUTH_WITH_ID, isNiAccount = false, authEoriAndCompanyMap)
 
         shouldContainCorrectAccountStatusMsgForStatusOpen(view, OPEN_CASH_ACC_WITH_AUTH_WITH_ID)
         shouldContainCorrectHeaderValues(view, OPEN_CASH_ACC_WITH_AUTH_WITH_ID)
@@ -83,9 +85,10 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
 
   private def viewAsDoc(accountId: String,
                         account: AccountWithAuthoritiesWithId,
-                        isNiAccount: Boolean = false): Document =
+                        isNiAccount: Boolean = false,
+                        authEoriAndCompanyMap: Map[String, String] = Map.empty): Document =
     Jsoup.parse(app.injector.instanceOf[ManageAuthoritiesTable].apply(
-      ManageAuthoritiesTableViewModel(accountId, account, isNiAccount)
+      ManageAuthoritiesTableViewModel(accountId, account, isNiAccount, authEoriAndCompanyMap)
     ).body)
 
   private def shouldContainCorrectAccountStatusMsgForStatusOpen(view: Document,
@@ -159,11 +162,16 @@ class ManageAuthoritiesTableSpec extends ViewTestHelper {
   }
 
   private def shouldContainCorrectElementValuesForAuthorityRows(view: Document,
-                                                                account: AccountWithAuthoritiesWithId): Assertion = {
+                                                                account: AccountWithAuthoritiesWithId,
+                                                                authEoriAndCompanyMap: Map[String, String] = Map.empty): Assertion = {
 
     val tableRowHtml = view.getElementsByClass("govuk-table__row").html()
 
     tableRowHtml.contains(messages("manageAuthorities.table.heading.user")) mustBe true
+
+    if(authEoriAndCompanyMap.contains(EORI_NUMBER)) {
+      tableRowHtml.contains(messages("manageAuthorities.table.heading.user")) mustBe true
+    }
     tableRowHtml.contains(messages("manageAuthorities.table.heading.startDate")) mustBe true
     tableRowHtml.contains(messages("manageAuthorities.table.heading.endDate")) mustBe true
     tableRowHtml.contains(messages("manageAuthorities.table.heading.balance")) mustBe true


### PR DESCRIPTION
Description - Code changes to implement ACC29 call when data is not present in the cache and to display company name on Manage authorities page. These changes are for both 

below have been done as part of this PR

- new repo and service have been added for authorised eoris and company info to store in the cache
- new test class
- new tests and updated existing tests
- remove unused code after removing the discontinued headers on the view
- minor refactoring