### PR TITLE
[MMCA-4976] Adding unit tests for SecureMessageConnectorSpec

### DIFF
--- a/app/assets/components/_notifications-bar.scss
+++ b/app/assets/components/_notifications-bar.scss
@@ -14,4 +14,3 @@
   .notifications-bar a:first-child {
     margin: 0 .8rem 0 0;
   }
-  

--- a/app/assets/components/_notifications-bar.scss
+++ b/app/assets/components/_notifications-bar.scss
@@ -1,9 +1,9 @@
 .notifications-bar {
     ul {
-      margin:0;
-      font-size:1rem;
+      margin: 0;
+      font-size: 1rem;
       li {
-        display:inline;
+        display: inline;
       }
     }
     a {

--- a/app/assets/components/_notifications-bar.scss
+++ b/app/assets/components/_notifications-bar.scss
@@ -1,0 +1,17 @@
+.notifications-bar {
+    ul {
+      margin:0 0 0 0;
+      font-size:1rem;
+      li {
+        display:inline;
+      }
+    }
+    a {
+      margin: 0 .8rem;
+    }
+  }
+  
+  .notifications-bar a:first-child {
+    margin: 0 .8rem 0 0;
+  }
+  

--- a/app/assets/components/_notifications-bar.scss
+++ b/app/assets/components/_notifications-bar.scss
@@ -1,6 +1,6 @@
 .notifications-bar {
     ul {
-      margin:0 0 0 0;
+      margin:0;
       font-size:1rem;
       li {
         display:inline;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,5 +4,6 @@ $hmrc-assets-path: "/customs/manage-authorities/assets/lib/hmrc-frontend/hmrc/";
 @import "lib/govuk-frontend/dist/govuk/base";
 
 @import "components/table";
+@import "components/notifications-bar";
 @import "manage-authorities";
 @import "shame";

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -55,4 +55,9 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
   val emailFrontendUrl: String = servicesConfig.baseUrl("customs-email-frontend") +
     configuration.get[String]("microservice.services.customs-email-frontend.context") +
     configuration.get[String]("microservice.services.customs-email-frontend.url")
+
+  val customsSecureMessagingBannerEndpoint: String =
+    configuration.get[Service]("microservice.services.customs-financials-secure-messaging-frontend").baseUrl +
+    configuration.get[String]("microservice.services.customs-financials-secure-messaging-frontend.context") +
+    configuration.get[String]("microservice.services.customs-financials-secure-messaging-frontend.banner-endpoint")
 }

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -57,7 +57,12 @@ class FrontendAppConfig @Inject()(configuration: Configuration, servicesConfig: 
     configuration.get[String]("microservice.services.customs-email-frontend.url")
 
   val customsSecureMessagingBannerEndpoint: String =
-    configuration.get[Service]("microservice.services.customs-financials-secure-messaging-frontend").baseUrl +
-    configuration.get[String]("microservice.services.customs-financials-secure-messaging-frontend.context") +
-    configuration.get[String]("microservice.services.customs-financials-secure-messaging-frontend.banner-endpoint")
+    s"${servicesConfig.baseUrl("customs-financials-secure-messaging-frontend")}" +
+    s"${configuration.get[String]("microservice.services.customs-financials-secure-messaging-frontend.context")}" +
+    s"${configuration.get[String]("microservice.services.customs-financials-secure-messaging-frontend.banner-endpoint")}"
+
+  val manageAuthoritiesServiceUrl: String =
+    s"${servicesConfig.baseUrl("customs-manage-authorities-frontend")}" +
+    s"${configuration.get[String]("microservice.services.customs-manage-authorities-frontend.context")}"
+
 }

--- a/app/connectors/SecureMessageConnector.scala
+++ b/app/connectors/SecureMessageConnector.scala
@@ -21,7 +21,7 @@ import javax.inject.Inject
 import play.api.http.Status
 import play.api.mvc.RequestHeader
 import play.api.{Logger, Logging}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, StringContextOps}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import uk.gov.hmrc.play.partials.{HeaderCarrierForPartialsConverter, HtmlPartial}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/connectors/SecureMessageConnector.scala
+++ b/app/connectors/SecureMessageConnector.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.FrontendAppConfig
+import javax.inject.Inject
+import play.api.http.Status
+import play.api.mvc.RequestHeader
+import play.api.{Logger, Logging}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, StringContextOps}
+import uk.gov.hmrc.play.partials.{HeaderCarrierForPartialsConverter, HtmlPartial}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SecureMessageConnector @Inject()(httpClient: HttpClient,
+                                       appConfig: FrontendAppConfig,
+                                       headerCarrierForPartialsConverter: HeaderCarrierForPartialsConverter)
+                                      (implicit ec: ExecutionContext)
+  extends Logging with Status {
+
+  private val log = Logger(this.getClass)
+
+  def getMessageCountBanner(returnToUrl: String)(implicit request: RequestHeader): Future[Option[HtmlPartial]] = {
+    implicit val hc: HeaderCarrier = headerCarrierForPartialsConverter.fromRequestWithEncryptedCookie(request)
+
+    val url = s"${appConfig.customsSecureMessagingBannerEndpoint}?return_to=$returnToUrl"
+
+    httpClient.GET[HtmlPartial](url).map {
+      case success@HtmlPartial.Success(_, _) => Some(success)
+      case HtmlPartial.Failure(_, _) => None
+    }.recover {
+      case exc =>
+        log.error(s"Problem loading message banner partial: ${exc.getMessage}")
+        None
+    }
+  }
+}

--- a/app/controllers/ManageAuthoritiesController.scala
+++ b/app/controllers/ManageAuthoritiesController.scala
@@ -56,7 +56,7 @@ class ManageAuthoritiesController @Inject()(override val messagesApi: MessagesAp
   def onPageLoad: Action[AnyContent] = (identify andThen checkEmailIsVerified).async {
     implicit request =>
 
-      val returnToUrl = appConfig.customsSecureMessagingBannerEndpoint + routes.ManageAuthoritiesController.onPageLoad.url
+      val returnToUrl = s"${appConfig.manageAuthoritiesServiceUrl}${routes.ManageAuthoritiesController.onPageLoad.url}"
 
       val response = for {
         xiEori <- dataStoreConnector.getXiEori(request.eoriNumber)

--- a/app/views/ManageAuthoritiesView.scala.html
+++ b/app/views/ManageAuthoritiesView.scala.html
@@ -34,7 +34,8 @@
 )
 
 @(
-    viewModel: ManageAuthoritiesViewModel
+    viewModel: ManageAuthoritiesViewModel,
+    maybeMessageBannerPartial: Option[HtmlFormat.Appendable]
 )(
     implicit request: Request[_],
     messages: Messages,
@@ -42,7 +43,9 @@
 )
 
 @layout(pageTitle = Some(titleNoForm("manageAuthorities.title", None, Seq())),
-        backLink = Some(appConfig.customsFinancialsFrontendHomepageUrl), isFullWidth = viewModel.hasAccounts) {
+        backLink = Some(appConfig.customsFinancialsFrontendHomepageUrl), 
+        isFullWidth = viewModel.hasAccounts,
+        maybeMessageBannerPartial = maybeMessageBannerPartial) {
 
     @h1(id=Some("manageAuthorities.heading"),
         msg = "manageAuthorities.title",

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -39,6 +39,7 @@
         deskpro: Boolean = true,
         welshToggle: Boolean = true,
         userResearchBanner: Boolean = true,
+        maybeMessageBannerPartial: Option[HtmlFormat.Appendable] = None,
         isFullWidth: Boolean = false
 )(contentBlock: Html)(implicit request: Request[_], appConfig: FrontendAppConfig, messages: Messages)
 
@@ -54,6 +55,10 @@
         case Some(text) => Some(text)
         case _ => Some(s"${messages("service.name")} - GOV.UK")
     }
+}
+
+@beforeContent = {
+    @if(maybeMessageBannerPartial.isDefined) { @maybeMessageBannerPartial }
 }
 
 @additionalHead = {
@@ -84,7 +89,7 @@
     serviceUrl = Some(appConfig.customsFinancialsFrontendHomepageUrl),
     signOutUrl = Some(controllers.routes.LogoutController.logout.url),
     backLinkUrl = backLink,
-    beforeContentBlock = None,
+    beforeContentBlock =if (maybeMessageBannerPartial.isDefined) Some(beforeContent) else None,
     additionalHeadBlock = Some(additionalHead),
     phaseBanner = Some(PhaseBanner(tag = Some(Tag(content = Text("BETA"))), content = HtmlContent(phaseBannerContent))),
     isWelshTranslationAvailable = welshToggle,

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -58,7 +58,8 @@
 }
 
 @beforeContent = {
-    @if(maybeMessageBannerPartial.isDefined) { @maybeMessageBannerPartial }
+    @maybeMessageBannerPartial.map(identity).getOrElse(HtmlFormat.empty)
+    @hmrcLanguageSelectHelper()
 }
 
 @additionalHead = {
@@ -89,7 +90,7 @@
     serviceUrl = Some(appConfig.customsFinancialsFrontendHomepageUrl),
     signOutUrl = Some(controllers.routes.LogoutController.logout.url),
     backLinkUrl = backLink,
-    beforeContentBlock =if (maybeMessageBannerPartial.isDefined) Some(beforeContent) else None,
+    beforeContentBlock = maybeMessageBannerPartial.map(_ => beforeContent),
     additionalHeadBlock = Some(additionalHead),
     phaseBanner = Some(PhaseBanner(tag = Some(Tag(content = Text("BETA"))), content = HtmlContent(phaseBannerContent))),
     isWelshTranslationAvailable = welshToggle,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,6 +69,14 @@ microservice {
       customs-financials-frontend {
         homepage = "http://localhost:9876/customs/payment-records/"
       }
+
+      customs-financials-secure-messaging-frontend {
+        host = localhost
+        port = 9842
+        protocol = http
+        context = "/customs/secure-messaging"
+        banner-endpoint = "/banner"
+      }
     }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -77,6 +77,14 @@ microservice {
         context = "/customs/secure-messaging"
         banner-endpoint = "/banner"
       }
+
+      customs-manage-authorities-frontend {
+        url = "http://localhost:9000/customs/manage-authorities"
+        host = localhost
+        port = 9000
+        protocol = http
+        context = "/customs/manage-authorities"
+      }
     }
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,6 +9,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "9.6.0",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % "1.8.0",
+    "uk.gov.hmrc" %% "play-partials-play-30" % "10.0.0",
     "org.typelevel" %% "cats-core" % "2.10.0"
   )
 

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -46,6 +46,12 @@ class FrontendAppConfigSpec extends SpecBase {
         appConfig.authorizedToViewUrl mustBe "http://localhost:9876/customs/payment-records/authorized-to-view"
       }
     }
+
+    "return customsSecureMessagingBannerEndpoint" in new Setup {
+      running(app) {
+        appConfig.customsSecureMessagingBannerEndpoint mustBe "http://localhost:9842/customs/secure-messaging/banner"
+      }
+    }
   }
 
   trait Setup {

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -52,6 +52,12 @@ class FrontendAppConfigSpec extends SpecBase {
         appConfig.customsSecureMessagingBannerEndpoint mustBe "http://localhost:9842/customs/secure-messaging/banner"
       }
     }
+
+    "return manageAuthoritiesServiceUrl" in new Setup {
+      running(app) {
+        appConfig.manageAuthoritiesServiceUrl mustBe "http://localhost:9000/customs/manage-authorities"
+      }
+    }
   }
 
   trait Setup {

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -74,5 +74,3 @@ class SecureMessageConnectorSpec extends SpecBase {
     ).build()
   }
 }
-
-

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar.mock
 import base.SpecBase
 import uk.gov.hmrc.play.partials.HtmlPartial
-import play.api.inject
+import play.api.{inject, Application}
 import scala.concurrent.Future
 import scala.util.Try
 import utils.StringUtils.emptyString
@@ -59,7 +59,7 @@ class SecureMessageConnectorSpec extends SpecBase {
 
       running(app) {
         val result = await(mockConnector.getMessageCountBanner(returnTo)(fakeRequest()))
-        result mustEqual None
+        result mustBe None
       }
     }
   }
@@ -69,8 +69,9 @@ class SecureMessageConnectorSpec extends SpecBase {
 
     protected val returnTo = "gov.uk"
 
-    val app = applicationBuilder().overrides(
+    val app: Application = applicationBuilder().overrides(
       inject.bind[SecureMessageConnector].toInstance(mockConnector)
     ).build()
+    
   }
 }

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import play.api.test.Helpers._
+import play.twirl.api.Html
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar.mock
+import base.SpecBase
+import uk.gov.hmrc.play.partials.HtmlPartial
+import play.api.inject
+import scala.concurrent.Future
+import scala.util.Try
+import utils.StringUtils.emptyString
+import play.api.mvc.RequestHeader
+
+class SecureMessageConnectorSpec extends SpecBase {
+
+  "getMessageCountBanner" should {
+
+    "return a valid message banner when the upstream call returns OK" in new Setup {
+      when(mockConnector.getMessageCountBanner(any[String])(any[RequestHeader]))
+        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some("Hello"), Html(emptyString)))))
+
+      running(app) {
+        val result = await(mockConnector.getMessageCountBanner(returnTo)(fakeRequest()))
+        result.get mustEqual HtmlPartial.Success(Some("Hello"), Html(emptyString))
+      }
+    }
+
+    "return None when the upstream call throws an Exception" in new Setup {
+      when(mockConnector.getMessageCountBanner(any[String])(any[RequestHeader]))
+        .thenReturn(Future.failed(new Exception("ahh")))
+
+      running(app) {
+        val result = Try(await(mockConnector.getMessageCountBanner(returnTo)(fakeRequest()))).toOption
+        result.isEmpty mustEqual true
+      }
+    }
+
+    "return None when the upstream call returns an unhappy response" in new Setup {
+      when(mockConnector.getMessageCountBanner(any[String])(any[RequestHeader]))
+        .thenReturn(Future.successful(None))
+
+      running(app) {
+        val result = await(mockConnector.getMessageCountBanner(returnTo)(fakeRequest()))
+        result mustEqual None
+      }
+    }
+  }
+
+  trait Setup {
+    val mockConnector: SecureMessageConnector = mock[SecureMessageConnector]
+
+    protected val returnTo = "gov.uk"
+
+    val app = applicationBuilder().overrides(
+      inject.bind[SecureMessageConnector].toInstance(mockConnector)
+    ).build()
+  }
+}
+
+

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -72,6 +72,5 @@ class SecureMessageConnectorSpec extends SpecBase {
     val app: Application = applicationBuilder().overrides(
       inject.bind[SecureMessageConnector].toInstance(mockConnector)
     ).build()
-    
   }
 }

--- a/test/controllers/ManageAuthoritiesControllerSpec.scala
+++ b/test/controllers/ManageAuthoritiesControllerSpec.scala
@@ -112,7 +112,6 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
 
         when(mockAuthEoriAndCompanyInfoService.retrieveAuthorisedEoriAndCompanyInfo(any, any)(any))
           .thenReturn(Future.successful(Some(eoriAndCompanyInfoMap)))
-
         when(mockSecureMessageConnector.getMessageCountBanner(any)(any)).thenReturn(Future.successful(None))
 
         val application: Application = applicationBuilder(userAnswers = Some(emptyUserAnswers))

--- a/test/controllers/ManageAuthoritiesControllerSpec.scala
+++ b/test/controllers/ManageAuthoritiesControllerSpec.scala
@@ -80,7 +80,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
 
           contentAsString(result) mustEqual
             view()(request, messages(application), appConfig).toString
-          
+
           verify(mockSecureMessageConnector).getMessageCountBanner(any)(any)
         }
       }
@@ -112,6 +112,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
 
         when(mockAuthEoriAndCompanyInfoService.retrieveAuthorisedEoriAndCompanyInfo(any, any)(any))
           .thenReturn(Future.successful(Some(eoriAndCompanyInfoMap)))
+
         when(mockSecureMessageConnector.getMessageCountBanner(any)(any)).thenReturn(Future.successful(None))
 
         val application: Application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
@@ -137,7 +138,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
           contentAsString(result) mustEqual
             view(ManageAuthoritiesViewModel(authoritiesWithId, accounts, eoriAndCompanyInfoMap), maybeMessageBannerPartial = None)(
               request, messages(application), appConfig).toString
-          
+
           verify(mockSecureMessageConnector).getMessageCountBanner(any)(any)
         }
       }

--- a/test/controllers/ManageAuthoritiesControllerSpec.scala
+++ b/test/controllers/ManageAuthoritiesControllerSpec.scala
@@ -127,7 +127,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
           status(result) mustEqual OK
 
           contentAsString(result) mustEqual
-            view(ManageAuthoritiesViewModel(authoritiesWithId, accounts, eoriAndCompanyInfoMap))(
+            view(ManageAuthoritiesViewModel(authoritiesWithId, accounts, eoriAndCompanyInfoMap), maybeMessageBannerPartial = None)(
               request, messages(application), appConfig).toString
         }
       }
@@ -173,7 +173,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
           status(result) mustEqual OK
 
           contentAsString(result) mustEqual
-            view(ManageAuthoritiesViewModel(authoritiesWithId, accounts, eoriAndCompanyInfoMap))(
+            view(ManageAuthoritiesViewModel(authoritiesWithId, accounts, eoriAndCompanyInfoMap), maybeMessageBannerPartial = None)(
               request, messages(application), appConfig).toString
         }
       }
@@ -217,7 +217,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar {
           status(result) mustEqual OK
 
           contentAsString(result) mustEqual
-            view(ManageAuthoritiesViewModel(emptyAuthoritiesWithId, accounts))(
+            view(ManageAuthoritiesViewModel(emptyAuthoritiesWithId, accounts), maybeMessageBannerPartial = None)(
               request, messages(application), appConfig).toString
         }
       }

--- a/test/views/ManageAuthoritiesViewSpec.scala
+++ b/test/views/ManageAuthoritiesViewSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.SpecBase
+import config.FrontendAppConfig
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.Application
+import play.api.i18n.Messages
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.{FakeRequest, Helpers}
+import views.html.ManageAuthoritiesView
+import viewmodels.ManageAuthoritiesViewModel
+import play.twirl.api.HtmlFormat
+import models.domain.{AuthoritiesWithId, CDSAccounts}
+
+class ManageAuthoritiesViewSpec extends SpecBase {
+
+  "ManageAuthoritiesView" should {
+    "display the correct page title" in new Setup {
+      view().title must include(messages("manageAuthorities.title"))
+    }
+
+    "display the heading title" in new Setup {
+      view().getElementById("manageAuthorities.heading").text mustBe messages("manageAuthorities.title")
+    }
+
+    "display notifications bar if provided" in new Setup {
+      override val maybeMessageBannerPartial: Option[HtmlFormat.Appendable] = Some(
+        HtmlFormat.raw(
+            """
+            <div class='notifications-bar'>Content</div>
+            """
+        )
+      )
+      view().select("div.notifications-bar").text mustBe "Content"
+    }
+
+  }
+
+  trait Setup {
+    implicit val csrfRequest: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", "/some/resource/path")
+
+    val app: Application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+    implicit val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+    implicit val messages: Messages = Helpers.stubMessages()
+
+    val viewModel: ManageAuthoritiesViewModel = ManageAuthoritiesViewModel(
+      authorities = AuthoritiesWithId(Nil),
+      accounts = CDSAccounts("testEori", List.empty),
+      auhorisedEoriAndCompanyMap = Map.empty
+    )
+    val maybeMessageBannerPartial: Option[HtmlFormat.Appendable] = None
+
+    def view(): Document = {
+      val htmlContent = app.injector.instanceOf[ManageAuthoritiesView]
+        .apply(viewModel, maybeMessageBannerPartial)(csrfRequest, messages, appConfig)
+        .body
+      Jsoup.parse(htmlContent)
+    }
+  }
+}


### PR DESCRIPTION
[Tasks]
- Implement header will all tabs on authorities page
- Added `SecureMessageConnector` class to the connectors package
- Added styles for the header
- Updated unit tests


<img width="838" alt="image" src="https://github.com/user-attachments/assets/fc9cbf0c-8444-4324-a6c2-75d3959b5c9e">
