### PR TITLE
[MMCA-5055] - remove targetJvm for Java 21 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import play.sbt.routes.RoutesKeys
 import sbt.Def
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings.{targetJvm, itSettings, scalaSettings, defaultSettings}
+import uk.gov.hmrc.DefaultBuildSettings.{itSettings, scalaSettings, defaultSettings}
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
 lazy val appName: String = "customs-manage-authorities-frontend"
@@ -46,7 +46,6 @@ lazy val root = (project in file("."))
   .settings(inConfig(Test)(testSettings) *)
   .settings(ThisBuild / useSuperShell := false)
   .settings(
-    targetJvm := "jvm-11",
     name := appName,
     RoutesKeys.routesImport += "models._",
     TwirlKeys.templateImports ++= Seq(


### PR DESCRIPTION
- [x] Services will need to be on Play 2.9 or 3.0 and using sbt 1.9.7, Scala 2.13.12 to use it.
- [x] Remove `targetJvm` in build.sbt
- [x] Check that the service runs locally on Java 21 first.
- [x] Update microservice job builders in build-jobs to opt in to Java 21.
- [x] Ensure build passes with Java 21.