### PR TITLE
[MMCA-5174] Added BrowserBackLink component

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const backLink = document.getElementById('browser-back-link');
+    if (backLink) {
+        backLink.addEventListener('click', function(event) {
+            event.preventDefault();
+            window.history.back();
+        });
+    }
+});

--- a/app/views/ManageAuthoritiesView.scala.html
+++ b/app/views/ManageAuthoritiesView.scala.html
@@ -39,7 +39,7 @@
 )
 
 @layout(pageTitle = Some(titleNoForm("manageAuthorities.title", None, Seq())),
-        backLink = Some(appConfig.customsFinancialsFrontendHomepageUrl), 
+        browserBackLink = Some(appConfig.customsFinancialsFrontendHomepageUrl),
         isFullWidth = viewModel.hasAccounts,
         maybeMessageBannerPartial = maybeMessageBannerPartial) {
 

--- a/app/views/components/browserBackLink.scala.html
+++ b/app/views/components/browserBackLink.scala.html
@@ -1,0 +1,25 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(govukBackLink: GovukBackLink)
+
+@(href: String)(implicit messages: Messages)
+
+@govukBackLink(BackLink(
+    href = href,
+    content = Text(messages("cf.back")),
+    attributes = Map("id" -> "browser-back-link")
+))

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -20,8 +20,11 @@
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage._
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.userresearchbanner.UserResearchBanner
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukBackLink
 @import config.FrontendAppConfig
 @import views.html.components.fullWidthMainContent
+@import views.html.components.browserBackLink
+@import views.html.helper.CSPNonce
 
 @this(
     appConfig: FrontendAppConfig,
@@ -30,11 +33,14 @@
     hmrcTimeoutDialog: HmrcTimeoutDialog,
     hmrcLanguageSelectHelper: HmrcLanguageSelectHelper,
     twoThirdsMainContent: TwoThirdsMainContent,
-    fullWidthMainContent: fullWidthMainContent
+    fullWidthMainContent: fullWidthMainContent,
+    govukBackLink: GovukBackLink,
+    browserBackLinkComponent: browserBackLink
 )
 
 @(pageTitle: Option[String] = None,
   backLink: Option[String] = None,
+  browserBackLink: Option[String] = None,
   helpAndSupport: Boolean = true,
   deskpro: Boolean = true,
   welshToggle: Boolean = true,
@@ -57,8 +63,13 @@
 }
 
 @beforeContent = {
-    @maybeMessageBannerPartial.map(identity).getOrElse(HtmlFormat.empty)
+    @maybeMessageBannerPartial.getOrElse(HtmlFormat.empty)
     @hmrcLanguageSelectHelper()
+
+    @{
+        browserBackLink.map(browserBackLinkComponent(_))
+            .getOrElse(backLink.map(link => govukBackLink(BackLink(href = link))).getOrElse(HtmlFormat.empty))
+    }
 }
 
 @additionalHead = {
@@ -71,6 +82,8 @@
         timeoutUrl = Some(controllers.routes.LogoutController.logoutNoSurvey.url)
     ))
     <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css"/>
+
+    <script @{CSPNonce.attr} src='@controllers.routes.Assets.versioned("javascripts/main.js")'></script>
 }
 
 @mainContent = {
@@ -91,10 +104,10 @@
             signOutUrl = Some(controllers.routes.LogoutController.logout.url),
             accessibilityStatementUrl = Some("/accessibility-statement/customs-financials")
         ),
-        backLink = backLink.filter(_.nonEmpty).map(BackLink(_)),
+        backLink = if (browserBackLink.isDefined) None else backLink.map(BackLink(_)),
         templateOverrides = TemplateOverrides(
             additionalHeadBlock = Some(additionalHead),
-            beforeContentBlock = maybeMessageBannerPartial.map(_ => beforeContent),
+            beforeContentBlock = if (maybeMessageBannerPartial.isDefined || browserBackLink.isDefined || backLink.isDefined) Some(beforeContent) else None,
             mainContentLayout = Some(if(isFullWidth) fullWidthMainContent(_) else twoThirdsMainContent(_))
         ),
         banners = Banners(
@@ -104,3 +117,4 @@
         isWelshTranslationAvailable = welshToggle,
     )
 )(mainContent)
+

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -25,7 +25,6 @@ cf.accounts.view-customs-account=rheoli tollau mewnforio a chyfrifon TAW
 
 cf.back=Yn ôl
 
-
 footer.accessibility=Datganiad hygyrchedd
 footer.cookies=Cwcis
 footer.privacy=Polisi preifatrwydd

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -23,6 +23,8 @@ cf.error.not-found.message.go-to-home-page-text1=Gallwch fynd
 cf.error.not-found.message.go-to-home-page-text2=yn ôl i reoli tollau mewnforio a chyfrifon TAW
 cf.accounts.view-customs-account=rheoli tollau mewnforio a chyfrifon TAW
 
+cf.back=Yn ôl
+
 
 footer.accessibility=Datganiad hygyrchedd
 footer.cookies=Cwcis

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -23,6 +23,8 @@ cf.error.not-found.message.go-to-home-page-text1=You can go
 cf.error.not-found.message.go-to-home-page-text2=back to manage import duties and VAT accounts
 cf.accounts.view-customs-account=manage import duties and VAT accounts
 
+cf.back=Back
+
 footer.accessibility   = Accessibility statement
 footer.cookies         = Cookies
 footer.privacy         = Privacy policy

--- a/test/views/components/BrowserBackLinkSpec.scala
+++ b/test/views/components/BrowserBackLinkSpec.scala
@@ -31,7 +31,7 @@ class BrowserBackLinkSpec extends SpecBase {
     "render the back link with correct attributes and text" in new Setup {
       running(app) {
         val output: HtmlFormat.Appendable = browserBackLinkView(
-          href = "/url",
+          href = "/url"
         )(messages(app))
 
         val html: Document = Jsoup.parse(contentAsString(output))
@@ -43,7 +43,7 @@ class BrowserBackLinkSpec extends SpecBase {
   }
 
   trait Setup {
-    val app: Application                       = applicationBuilder().build()
-    val browserBackLinkView: browserBackLink   = app.injector.instanceOf[browserBackLink]
+    val app: Application                     = applicationBuilder().build()
+    val browserBackLinkView: browserBackLink = app.injector.instanceOf[browserBackLink]
   }
 }

--- a/test/views/components/BrowserBackLinkSpec.scala
+++ b/test/views/components/BrowserBackLinkSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.Application
+import play.api.test.Helpers.{contentAsString, running}
+import play.twirl.api.HtmlFormat
+import base.SpecBase
+import play.api.test.Helpers.defaultAwaitTimeout
+import views.html.components.browserBackLink
+
+class BrowserBackLinkSpec extends SpecBase {
+
+  "BrowserBackLink component" should {
+
+    "render the back link with correct attributes and text" in new Setup {
+      running(app) {
+        val output: HtmlFormat.Appendable = browserBackLinkView(
+          href = "/url",
+        )(messages(app))
+
+        val html: Document = Jsoup.parse(contentAsString(output))
+
+        val linkElement = html.getElementById("browser-back-link")
+        linkElement.attr("href") mustBe "/url"
+      }
+    }
+  }
+
+  trait Setup {
+    val app: Application                       = applicationBuilder().build()
+    val browserBackLinkView: browserBackLink   = app.injector.instanceOf[browserBackLink]
+  }
+}


### PR DESCRIPTION
[Tasks]
- Added `BrowserBackLink` component with `dynamic` href
- Included `main.js` to handle browser back functionality
- Added unit tests for `BrowserBackLink`
- Added `browserBackLink` to layout to support browser-based navigation
- Added fallback: When JavaScript is disabled, clicking the back link will route the user to the home page (/customs/payment-records)

[ToDo]
- Add missing unit test for `Layout`