### PR TITLE
MMCA-5205 EU EORI - Updates to customs-manage-authorities-frontend for EORI regex/checks

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -34,6 +34,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
   lazy val xClientIdHeader: String = configuration.get[String]("microservice.services.sdes.x-client-id")
   lazy val fixedDateTime: Boolean  = configuration.get[Boolean]("features.fixed-system-time")
   lazy val xiEoriEnabled: Boolean  = configuration.get[Boolean]("features.xi-eori-enabled")
+  lazy val euEoriEnabled: Boolean  = configuration.get[Boolean]("features.eu-eori-enabled")
   lazy val timeout: Int            = configuration.get[Int]("timeout.timeout")
 
   lazy val countdown: Int = configuration.get[Int]("timeout.countdown")

--- a/app/forms/EoriNumberFormProvider.scala
+++ b/app/forms/EoriNumberFormProvider.scala
@@ -16,17 +16,18 @@
 
 package forms
 
+import config.FrontendAppConfig
 import forms.mappings.Mappings
 import play.api.data.Form
 
 import javax.inject.Inject
 
-class EoriNumberFormProvider @Inject() extends Mappings {
+class EoriNumberFormProvider @Inject() (frontendAppConfig: FrontendAppConfig) extends Mappings {
 
   def apply(): Form[String] =
     Form(
       "value" -> text(errorKey = "eoriNumber.error.required")
-        .verifying(checkEORI(invalidFormatErrorKey = "eoriNumber.error.format"))
+        .verifying(checkEORI(invalidFormatErrorKey = "eoriNumber.error.format", frontendAppConfig.euEoriEnabled))
     )
 
 }

--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -99,7 +99,6 @@ package object models {
           JsSuccess(JsArray(updatedJsArray))
 
         case valueToRemoveFrom: JsArray => JsError(s"array index out of bounds: $index, $valueToRemoveFrom")
-        case _                          => JsError(s"cannot set an index on $valueToRemoveFrom")
       }
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -100,6 +100,7 @@ microservice {
 features {
   fixed-system-time = false
   xi-eori-enabled = true
+  eu-eori-enabled = false
 }
 
 metrics {

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -28,6 +28,7 @@ class FrontendAppConfigSpec extends SpecBase {
         appConfig.appName mustBe "customs-manage-authorities-frontend"
         appConfig.feedbackUrl mustBe "https://www.development.tax.service.gov.uk/feedback/CDS-FIN"
         appConfig.xiEoriEnabled mustBe true
+        appConfig.euEoriEnabled mustBe false
 
         appConfig.emailFrontendUrl mustBe "http://localhost:9898/manage-email-cds/service/customs-finance"
         appConfig.authorizedToViewUrl mustBe "http://localhost:9876/customs/payment-records/authorized-to-view"

--- a/test/controllers/add/EoriNumberControllerSpec.scala
+++ b/test/controllers/add/EoriNumberControllerSpec.scala
@@ -498,11 +498,12 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
   trait SetUp {
     def onwardRoute: Call = Call("GET", "/foo")
 
-    val formProvider       = new EoriNumberFormProvider()
-    val form: Form[String] = formProvider()
-
     val mockConnector: CustomsFinancialsConnector         = mock[CustomsFinancialsConnector]
     val mockDataStoreConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
+    val frontendAppConfig: FrontendAppConfig              = applicationBuilder().build().injector.instanceOf[FrontendAppConfig]
+
+    val formProvider       = new EoriNumberFormProvider(frontendAppConfig)
+    val form: Form[String] = formProvider()
 
     implicit lazy val hc: HeaderCarrier = HeaderCarrier()
 

--- a/test/forms/EoriNumberFormProviderSpec.scala
+++ b/test/forms/EoriNumberFormProviderSpec.scala
@@ -16,6 +16,7 @@
 
 package forms
 
+import config.FrontendAppConfig
 import forms.behaviours.StringFieldBehaviours
 import forms.mappings.Constraints
 import org.scalacheck.Gen
@@ -33,7 +34,8 @@ class EoriNumberFormProviderSpec extends StringFieldBehaviours with Constraints 
     } yield s"GB$digits"
   }
 
-  val form = new EoriNumberFormProvider()()
+  private val frontendAppConfig = applicationBuilder().build().injector.instanceOf[FrontendAppConfig]
+  val form                      = new EoriNumberFormProvider(frontendAppConfig)()
 
   ".value" must {
     val requiredKey = "eoriNumber.error.required"

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -248,24 +248,59 @@ class ConstraintsSpec extends SpecBase with ScalaCheckPropertyChecks with Genera
     }
   }
 
-  "checkEORI" must {
+  "checkEORI" when {
 
-    "return valid when GBN EORI is provided" in {
-      val result = checkEORI("error.invalid2")("GBN45365789211")
+    "eu eori flag is enabled" must {
+      "return valid when GBN EORI is provided" in {
+        val result = checkEORI("error.invalid2", true)("GBN45365789211")
 
-      result mustEqual Valid
+        result mustEqual Valid
+      }
+
+      "return Invalid when an incorrect EORI format is provided" in {
+        val result = checkEORI("error.invalid2", true)("XI45394830957499865767")
+
+        result mustEqual Invalid("error.invalid2", """^[A-Z]{2}[0-9A-Z]{1,15}$""")
+      }
+
+      "return Valid for an input that does not match the expression" in {
+        val result = checkEORI("error.invalid2", true)("GB123456789102")
+
+        result mustEqual Valid
+      }
+
+      "return Valid when an EU EORI is provided" in {
+        val result = checkEORI("error.invalid2", true)("DE123456789012")
+
+        result mustEqual Valid
+      }
     }
 
-    "return Invalid when an incorrect EORI format is provided" in {
-      val result = checkEORI("error.invalid2")("XI453")
+    "eu eori flag is disabled" must {
 
-      result mustEqual Invalid("error.invalid2", """GB\d{12}""")
-    }
+      "return valid when GBN EORI is provided" in {
+        val result = checkEORI("error.invalid2", false)("GBN45365789211")
 
-    "return Valid for an input that does not match the expression" in {
-      val result = checkEORI("error.invalid2")("GB123456789102")
+        result mustEqual Valid
+      }
 
-      result mustEqual Valid
+      "return Invalid when an incorrect EORI format is provided" in {
+        val result = checkEORI("error.invalid2", false)("XI453")
+
+        result mustEqual Invalid("error.invalid2", """GB\d{12}""")
+      }
+
+      "return Valid for an input that does not match the expression" in {
+        val result = checkEORI("error.invalid2", false)("GB123456789102")
+
+        result mustEqual Valid
+      }
+
+      "return Invalid when an EU EORI is provided" in {
+        val result = checkEORI("error.invalid2", false)("DE123456789012")
+
+        result mustEqual Invalid("error.invalid2", """GB\d{12}""")
+      }
     }
   }
 

--- a/test/views/add/EoriNumberViewSpec.scala
+++ b/test/views/add/EoriNumberViewSpec.scala
@@ -157,7 +157,7 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
     implicit val appConfig: FrontendAppConfig                     = app.injector.instanceOf[FrontendAppConfig]
     implicit val messages: Messages                               = Helpers.stubMessages()
 
-    private val formProvider = new EoriNumberFormProvider()
+    private val formProvider = new EoriNumberFormProvider(appConfig)
     val form                 = formProvider()
 
     lazy val normalModeBackLinkRoute: Call = controllers.routes.ManageAuthoritiesController.onPageLoad()

--- a/test/views/components/InputCheckboxesSpec.scala
+++ b/test/views/components/InputCheckboxesSpec.scala
@@ -17,6 +17,7 @@
 package views.components
 
 import base.SpecBase
+import config.FrontendAppConfig
 import forms.EoriNumberFormProvider
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -71,12 +72,13 @@ class InputCheckboxesSpec extends SpecBase {
   trait Setup {
     val app: Application       = applicationBuilder().build()
     implicit val msg: Messages = messages(app)
+    private val appConfig      = app.injector.instanceOf[FrontendAppConfig]
 
-    val validForm: Form[String]   = new EoriNumberFormProvider()
+    val validForm: Form[String]   = new EoriNumberFormProvider(appConfig)
       .apply()
       .bind(Map("value" -> "GB123456789012"))
     val invalidForm: Form[String] =
-      new EoriNumberFormProvider().apply().bind(Map("value" -> "3456789012"))
+      new EoriNumberFormProvider(appConfig).apply().bind(Map("value" -> "3456789012"))
     val items                     = Seq(
       CheckboxItem(
         name = Some("value[0]"),

--- a/test/views/components/InputTextSpec.scala
+++ b/test/views/components/InputTextSpec.scala
@@ -17,6 +17,7 @@
 package views.components
 
 import base.SpecBase
+import config.FrontendAppConfig
 import forms.EoriNumberFormProvider
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
@@ -99,9 +100,10 @@ class InputTextSpec extends SpecBase {
   trait Setup {
     val app: Application       = applicationBuilder().build()
     implicit val msg: Messages = messages(app)
+    private val appConfig      = app.injector.instanceOf[FrontendAppConfig]
 
-    val validForm: Form[String]   = new EoriNumberFormProvider().apply().bind(Map("value" -> "GB123456789012"))
-    val invalidForm: Form[String] = new EoriNumberFormProvider().apply().bind(Map("value" -> "3456789012"))
+    val validForm: Form[String]   = new EoriNumberFormProvider(appConfig).apply().bind(Map("value" -> "GB123456789012"))
+    val invalidForm: Form[String] = new EoriNumberFormProvider(appConfig).apply().bind(Map("value" -> "3456789012"))
 
     val detailsSummaryText = "summaryText"
     val detailsText        = "text"


### PR DESCRIPTION
- [x] Add eu eori enabled flag, set to false locally
- [x] Add updated regex pattern for testing EORIs when flag is enabled
- [x] checkEori method dependent on flag
- [x] Amended tests 
- [x] Added flag to app-config-* files