### PR TITLE
MMCA-5236 Add new endpoint without EORI in url

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,7 +14,9 @@ GET        /not-subscribed-for-cds                                controllers.Un
 GET        /manage-account-authorities                            controllers.ManageAuthoritiesController.onPageLoad()
 GET        /manage-account-authorities-unavailable                controllers.ManageAuthoritiesController.unavailable()
 GET        /manage-account-authorities/account-unavailable        controllers.ManageAuthoritiesController.validationFailure()
+
 GET        /account-authorities/fetch-authorities/:eori           controllers.ManageAuthoritiesController.fetchAuthoritiesOnMIDVAHomePageLoad(eori)
+GET        /account-authorities/fetch-authorities                 controllers.ManageAuthoritiesController.fetchAuthoritiesOnMIDVAHomePageLoadV2()
 
 GET        /view-authority/:accountId/:authorityId                controllers.ViewAuthorityController.onPageLoad(accountId, authorityId)
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapVersion = "9.11.0"
-  private val mongoVersion = "2.5.0"
+  private val mongoVersion = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.9.9
+sbt.version=1.10.10
 hmrc-frontend-scaffold.version=0.15.0

--- a/test/controllers/actions/VerifyAccountNumbersActionSpec.scala
+++ b/test/controllers/actions/VerifyAccountNumbersActionSpec.scala
@@ -29,7 +29,7 @@ import play.api.http.Status.SEE_OTHER
 import play.api.mvc.{AnyContentAsEmpty, ResponseHeader, Result}
 import services.AuthorisedAccountsService
 import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, Name}
+import uk.gov.hmrc.auth.core.retrieve.Credentials
 import utils.StringUtils.emptyString
 
 import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
EORI is retrieved from authentication credentials

- [x] Endpoint tested with manual request