### PR TITLE
[MMCA-5214] Simplify EoriNumberView hint logic

### DIFF
--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -35,7 +35,7 @@ import views.html.add.EoriNumberView
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Success, Try}
+import scala.util.Success
 import scala.xml.dtd.ValidationException
 
 class EoriNumberController @Inject() (
@@ -205,10 +205,8 @@ class EoriNumberController @Inject() (
     Future {
       if (!requestEori.equals(eoriFromUserAnswers)) {
         userAnswers.set(AccountsPage, List()) match {
-          case Success(value) =>
-            value.set(EoriDetailsCorrectPage, EoriDetailsCorrect.No).getOrElse(value)
-          case _              =>
-            userAnswers
+          case Success(value) => value.set(EoriDetailsCorrectPage, EoriDetailsCorrect.No).getOrElse(value)
+          case _              => userAnswers
         }
       } else {
         userAnswers

--- a/app/controllers/add/EoriNumberController.scala
+++ b/app/controllers/add/EoriNumberController.scala
@@ -62,8 +62,9 @@ class EoriNumberController @Inject() (
     }
 
     val isXiEoriEnabled = appConfig.xiEoriEnabled
+    val isEuEoriEnabled = appConfig.euEoriEnabled
 
-    Ok(view(preparedForm, mode, navigator.backLinkRouteForEORINUmberPage(mode), isXiEoriEnabled))
+    Ok(view(preparedForm, mode, navigator.backLinkRouteForEORINUmberPage(mode), isXiEoriEnabled, isEuEoriEnabled))
   }
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData).async { implicit request =>
@@ -73,7 +74,7 @@ class EoriNumberController @Inject() (
         formWithErrors =>
           Future.successful(
             BadRequest(
-              view(formWithErrors, mode, navigator.backLinkRouteForEORINUmberPage(mode), appConfig.xiEoriEnabled)
+              view(formWithErrors, mode, navigator.backLinkRouteForEORINUmberPage(mode), appConfig.xiEoriEnabled, appConfig.euEoriEnabled)
             )
           ),
         eoriNumber => processValidInput(mode, request, eoriNumber)(appConfig, hc, request2Messages)
@@ -139,7 +140,8 @@ class EoriNumberController @Inject() (
             form.withError("value", "eoriNumber.error.invalid").fill(eori),
             mode,
             navigator.backLinkRouteForEORINUmberPage(mode),
-            appConfig.xiEoriEnabled
+            appConfig.xiEoriEnabled,
+            appConfig.euEoriEnabled
           )(request, msgs, appConfig)
         )
       case _                      => Redirect(controllers.routes.TechnicalDifficulties.onPageLoad)
@@ -157,7 +159,8 @@ class EoriNumberController @Inject() (
             form.withError("value", "eoriNumber.error.invalid").fill(eori),
             mode,
             navigator.backLinkRouteForEORINUmberPage(mode),
-            appConfig.xiEoriEnabled
+            appConfig.xiEoriEnabled,
+            appConfig.euEoriEnabled
           )
         )
     }
@@ -173,7 +176,8 @@ class EoriNumberController @Inject() (
           form.withError("value", errorMsgKey).fill(inputEoriNumber),
           mode,
           navigator.backLinkRouteForEORINUmberPage(mode),
-          appConfig.xiEoriEnabled
+          appConfig.xiEoriEnabled,
+          appConfig.euEoriEnabled
         )(request, msgs, appConfig)
       )
     )

--- a/app/views/add/EoriNumberView.scala.html
+++ b/app/views/add/EoriNumberView.scala.html
@@ -49,14 +49,11 @@
     @errorSummary(form.errors)
 
     @{
-      val (labelHintKey, detailsTextKey) =
-        if (xiEoriEnabled) {
-          ("eoriNumber.hint.xi", "eoriNumber.details.text")
-        } else if (euEoriEnabled) {
-          ("eoriNumber.hint.eu", "eoriNumber.details.text.eu")
-        } else {
-          ("eoriNumber.hint", "eoriNumber.details.text")
-        }
+      val (labelHintKey, detailsTextKey) = (xiEoriEnabled, euEoriEnabled) match {
+        case (true, _)       => ("eoriNumber.hint.xi", "eoriNumber.details.text")
+        case (false, true)   => ("eoriNumber.hint.eu", "eoriNumber.details.text.eu")
+        case (false, false)  => ("eoriNumber.hint", "eoriNumber.details.text")
+      }
 
       val inputHint = InputTextHint(
         Some(DetailsHint("eoriNumber.details.label", detailsTextKey)),
@@ -78,4 +75,3 @@
     @button("site.saveAndContinue")
   }
 }
-

--- a/app/views/add/EoriNumberView.scala.html
+++ b/app/views/add/EoriNumberView.scala.html
@@ -17,73 +17,65 @@
 @import models.Mode
 @import views.html.templates.Layout
 @import config.FrontendAppConfig
-@import views.ViewUtils.{InputTextHint,DetailsHint,LabelHint}
+@import views.ViewUtils.{InputTextHint, DetailsHint, LabelHint}
 
 @this(
-    layout: Layout,
-    formHelper: FormWithCSRF,
-    errorSummary: components.errorSummary,
-    button: components.button,
-    inputText: components.inputText
+  layout: Layout,
+  formHelper: FormWithCSRF,
+  errorSummary: components.errorSummary,
+  button: components.button,
+  inputText: components.inputText
 )
 
 @(
-    form: Form[_],
-    mode: Mode,
-    call: Call,
-    xiEoriEnabled: Boolean
+  form: Form[_],
+  mode: Mode,
+  call: Call,
+  xiEoriEnabled: Boolean,
+  euEoriEnabled: Boolean
 )(
-    implicit request: Request[_],
-    messages: Messages,
-    appConfig: FrontendAppConfig
+  implicit request: Request[_],
+  messages: Messages,
+  appConfig: FrontendAppConfig
 )
 
-@layout(pageTitle = Some(title(form, "eoriNumber.title", None, Seq())), backLink = Some(call)) {
+@layout(
+  pageTitle = Some(title(form, "eoriNumber.title", None, Seq())),
+  backLink = Some(call)
+) {
 
-    @formHelper(action = controllers.add.routes.EoriNumberController.onSubmit(mode)) {
+  @formHelper(action = controllers.add.routes.EoriNumberController.onSubmit(mode)) {
 
-        @errorSummary(form.errors)
+    @errorSummary(form.errors)
 
-        @if(xiEoriEnabled) {
-            @inputText(
-                form,
-                id = "value",
-                name = "value",
-                label = "eoriNumber.heading",
-                hint = Some(InputTextHint(
-                                Some(
-                                    DetailsHint("eoriNumber.details.label", "eoriNumber.details.text")
-                                    ),
-                                Some(
-                                    LabelHint("eoriNumber.hint.xi", "govuk-hint govuk-!-margin-top-6")
-                                )
-                        )
-                    ),
-                isPageHeading = true,
-                classes = Some("govuk-!-width-two-thirds"),
-                labelClasses = Some("govuk-!-margin-bottom-7")
-            )
-        }else{
-            @inputText(
-                form,
-                id = "value",
-                name = "value",
-                label = "eoriNumber.heading",
-                hint = Some(InputTextHint(
-                                Some(
-                                    DetailsHint("eoriNumber.details.label", "eoriNumber.details.text")
-                                    ),
-                                Some(
-                                    LabelHint("eoriNumber.hint", "govuk-hint govuk-!-margin-top-6")
-                                )
-                        )
-                    ),
-                isPageHeading = true,
-                classes = Some("govuk-!-width-two-thirds"),
-                labelClasses = Some("govuk-!-margin-bottom-7")
-            )
+    @{
+      val (labelHintKey, detailsTextKey) =
+        if (xiEoriEnabled) {
+          ("eoriNumber.hint.xi", "eoriNumber.details.text")
+        } else if (euEoriEnabled) {
+          ("eoriNumber.hint.eu", "eoriNumber.details.text.eu")
+        } else {
+          ("eoriNumber.hint", "eoriNumber.details.text")
         }
 
-        @button("site.saveAndContinue")
+      val inputHint = InputTextHint(
+        Some(DetailsHint("eoriNumber.details.label", detailsTextKey)),
+        Some(LabelHint(labelHintKey, "govuk-hint govuk-!-margin-top-6"))
+      )
+
+      inputText(
+        form,
+        id = "value",
+        name = "value",
+        label = "eoriNumber.heading",
+        hint = Some(inputHint),
+        isPageHeading = true,
+        classes = Some("govuk-!-width-two-thirds"),
+        labelClasses = Some("govuk-!-margin-bottom-7")
+      )
     }
+
+    @button("site.saveAndContinue")
+  }
 }
+

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -147,6 +147,7 @@ eoriNumber.title=Beth yw rhif EORI y cwmni neu’r person rydych am roi awdurdod
 eoriNumber.heading=Beth yw rhif EORI y cwmni neu’r person rydych am roi awdurdod iddo?
 eoriNumber.hint=Mae rhif EORI yn dechrau gyda GB neu GBN. <br>Er enghraifft, GB345834921000 neu GBN10537914000.
 eoriNumber.hint.xi=Mae rhifau EORI yn dechrau gyda GB neu XI, wedi’i ddilyn gan 12 llythyren neu digid. Er enghraifft, GB345834921000 neu XI345834921000.
+eoriNumber.hint.eu= Mae rhifau EORI yn dechrau â 2 lythyren (sef cod y wlad), ac yna 1 i 15 llythyren a rhif. Er enghraifft, GB345834921000 neu XI345834921000 
 eoriNumber.checkYourAnswersLabel=Rhif EORI y defnyddiwr
 eoriNumber.error.required=Nodwch rif EORI
 eoriNumber.error.format=Nodwch rif EORI yn y fformat cywir
@@ -154,7 +155,7 @@ eoriNumber.error.invalid = Nodwch EORI sydd wedi’i gofrestru gyda CThEM
 eoriNumber.error.authorise-own-eori = Ni allwch awdurdodi eich rhif EORI eich hun
 eoriNumber.details.label = Defnyddio’ch cyfrif gohirio tollau ar gyfer Gogledd Iwerddon
 eoriNumber.details.text = Er mwyn rhoi awdurdod i gwmni neu berson ddefnyddio’ch cyfrif gohirio tollau ar gyfer Gogledd Iwerddon, mae’n rhaid i chi ddefnyddio ei rif EORI sy’n dechrau gydag XI.
-
+eoriNumber.details.text.eu = Gallwch ond rhoi awdurdod i rif EORI sy’n dechrau gydag ‘XI’ neu god gwlad yn y UE i ddefnyddio’ch cyfrif gohirio tollau ar gyfer Gogledd Iwerddon.
 
 # Which accounts to add an authority to view
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -146,6 +146,7 @@ eoriNumber.title = What is the EORI number of the company or person you want to 
 eoriNumber.heading = What is the EORI number of the company or person you want to give authority to?
 eoriNumber.hint = An EORI number starts GB or GBN. <br> For example, GB345834921000 or GBN10537914000.
 eoriNumber.hint.xi = EORI numbers start with GB or XI followed by 12 letters or digits.<br> For example, GB345834921000 or XI345834921000.
+eoriNumber.hint.eu = EORI numbers start with 2 letters (these are the country code), followed by 1 to 15 letters and numbers. For example, GB345834921000 or XI345834921000
 eoriNumber.checkYourAnswersLabel = User EORI number
 eoriNumber.error.required = Enter an EORI number
 eoriNumber.error.format = Enter an EORI number in the correct format
@@ -153,7 +154,7 @@ eoriNumber.error.invalid = Enter an EORI that has been registered with HMRC
 eoriNumber.error.authorise-own-eori = You cannot authorise your own EORI number
 eoriNumber.details.label = Using your Northern Ireland duty deferment account
 eoriNumber.details.text = To give authority to a company or person to use your duty deferment account for Northern Ireland, you must use their EORI number starting with XI.
-
+eoriNumber.details.text.eu = You can only give authority to an EORI number starting with XI or an EU country code to use your Northern Ireland duty deferment account. 
 
 # Which accounts to add an authority to view
 

--- a/test/controllers/add/EoriNumberControllerSpec.scala
+++ b/test/controllers/add/EoriNumberControllerSpec.scala
@@ -435,9 +435,9 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         val xiEoriEnabled = true
         contentAsString(result) mustEqual
           view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
-            request, 
-            messages(application), 
-            appConfig 
+            request,
+            messages(application),
+            appConfig
           ).toString
       }
     }
@@ -471,8 +471,8 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
 
         contentAsString(result) mustEqual
           view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
-            request, 
-            messages(application), 
+            request,
+            messages(application),
             appConfig
           ).toString
       }

--- a/test/controllers/add/EoriNumberControllerSpec.scala
+++ b/test/controllers/add/EoriNumberControllerSpec.scala
@@ -59,7 +59,11 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         status(result) mustEqual OK
 
         contentAsString(result) mustEqual
-          view(form, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
+          view(form, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
+            request,
+            messages(application),
+            appConfig
+          ).toString
       }
     }
 
@@ -398,7 +402,11 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         val xiEoriEnabled = true
 
         contentAsString(result) mustEqual
-          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
+          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
+            request,
+            messages(application),
+            appConfig
+          ).toString
       }
     }
 
@@ -426,7 +434,11 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
 
         val xiEoriEnabled = true
         contentAsString(result) mustEqual
-          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
+          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
+            request, 
+            messages(application), 
+            appConfig 
+          ).toString
       }
     }
 
@@ -458,7 +470,11 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         val xiEoriEnabled = true
 
         contentAsString(result) mustEqual
-          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
+          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
+            request, 
+            messages(application), 
+            appConfig
+          ).toString
       }
     }
 

--- a/test/controllers/add/EoriNumberControllerSpec.scala
+++ b/test/controllers/add/EoriNumberControllerSpec.scala
@@ -59,7 +59,7 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         status(result) mustEqual OK
 
         contentAsString(result) mustEqual
-          view(form, NormalMode, backLinkRoute, xiEoriEnabled)(request, messages(application), appConfig).toString
+          view(form, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
       }
     }
 
@@ -84,7 +84,7 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         status(result) mustEqual OK
 
         contentAsString(result) mustEqual
-          view(form.fill("answer"), NormalMode, backLinkRoute, xiEoriEnabled)(
+          view(form.fill("answer"), NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(
             request,
             messages(application),
             appConfig
@@ -398,7 +398,7 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         val xiEoriEnabled = true
 
         contentAsString(result) mustEqual
-          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled)(request, messages(application), appConfig).toString
+          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
       }
     }
 
@@ -426,7 +426,7 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
 
         val xiEoriEnabled = true
         contentAsString(result) mustEqual
-          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled)(request, messages(application), appConfig).toString
+          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
       }
     }
 
@@ -458,7 +458,7 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
         val xiEoriEnabled = true
 
         contentAsString(result) mustEqual
-          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled)(request, messages(application), appConfig).toString
+          view(boundForm, NormalMode, backLinkRoute, xiEoriEnabled, euEoriEnabled)(request, messages(application), appConfig).toString
       }
     }
 
@@ -502,6 +502,7 @@ class EoriNumberControllerSpec extends SpecBase with MockitoSugar {
     val mockConnector: CustomsFinancialsConnector         = mock[CustomsFinancialsConnector]
     val mockDataStoreConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
     val frontendAppConfig: FrontendAppConfig              = applicationBuilder().build().injector.instanceOf[FrontendAppConfig]
+    val euEoriEnabled: Boolean                            = false
 
     val formProvider       = new EoriNumberFormProvider(frontendAppConfig)
     val form: Form[String] = formProvider()

--- a/test/views/add/EoriNumberViewSpec.scala
+++ b/test/views/add/EoriNumberViewSpec.scala
@@ -88,6 +88,7 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
 
       normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
       normalModeView().getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text.eu"
+
       val hintLabelElement: Elements = normalModeView().getElementsByClass("govuk-!-margin-top-6")
       hintLabelElement.html() mustBe "eoriNumber.hint.eu"
     }
@@ -111,8 +112,36 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
 
       normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
       normalModeView().getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text"
+
       val hintLabelElement: Elements = normalModeView().getElementsByClass("govuk-!-margin-top-6")
       hintLabelElement.html() mustBe "eoriNumber.hint"
+
+      normalModeView().getElementsByTag("button").get(1).html() mustBe "site.saveAndContinue"
+    }
+
+    "display the correct guidance in Check mode with all EORI flags disabled" in new Setup {
+      override val xiEoriEnabled = false
+      override val euEoriEnabled = false
+
+      override def checkModeView(): Document = Jsoup.parse(
+        app.injector
+          .instanceOf[EoriNumberView]
+          .apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+          .body
+      )
+
+      val detailsHintElement: Element = checkModeView().getElementById("value-hint-details")
+      val hintLabelElement: Elements  = checkModeView().getElementsByClass("govuk-!-margin-top-6")
+
+      checkModeView().title() mustBe "eoriNumber.title - service.name - site.govuk"
+
+      detailsHintElement.getElementById("value-hint-title").html() mustBe
+        "eoriNumber.details.label"
+      detailsHintElement.getElementsByClass("govuk-body").html() mustBe
+        "eoriNumber.details.text"
+      hintLabelElement.html() mustBe "eoriNumber.hint"
+
+      checkModeView().getElementsByTag("button").get(1).text() mustBe messages("site.saveAndContinue")
     }
 
     "when back-link is clicked returns to previous page on Normal Mode" in new Setup {

--- a/test/views/add/EoriNumberViewSpec.scala
+++ b/test/views/add/EoriNumberViewSpec.scala
@@ -74,10 +74,16 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
       override val euEoriEnabled = true
 
       override def normalModeView(): Document = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
+        app.injector
+          .instanceOf[EoriNumberView]
+          .apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+          .body
       )
-      override def checkModeView(): Document = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
+      override def checkModeView(): Document  = Jsoup.parse(
+        app.injector
+          .instanceOf[EoriNumberView]
+          .apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+          .body
       )
 
       normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
@@ -91,10 +97,16 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
       override val euEoriEnabled = false
 
       override def normalModeView(): Document = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
+        app.injector
+          .instanceOf[EoriNumberView]
+          .apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+          .body
       )
-      override def checkModeView(): Document = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
+      override def checkModeView(): Document  = Jsoup.parse(
+        app.injector
+          .instanceOf[EoriNumberView]
+          .apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+          .body
       )
 
       normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
@@ -120,25 +132,30 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
 
     implicit val csrfRequest: FakeRequest[AnyContentAsEmpty.type] =
       fakeRequest("GET", "/some/resource/path")
-    val app: Application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-    implicit val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
-    implicit val messages: Messages = Helpers.stubMessages()
+    val app: Application                                          = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+    implicit val appConfig: FrontendAppConfig                     = app.injector.instanceOf[FrontendAppConfig]
+    implicit val messages: Messages                               = Helpers.stubMessages()
 
     private val formProvider = new EoriNumberFormProvider(appConfig)
-    val form = formProvider()
+    val form                 = formProvider()
 
     lazy val normalModeBackLinkRoute: Call = controllers.routes.ManageAuthoritiesController.onPageLoad()
-    lazy val checkModeBackLinkRoute: Call = controllers.add.routes.AuthorisedUserController.onPageLoad()
+    lazy val checkModeBackLinkRoute: Call  = controllers.add.routes.AuthorisedUserController.onPageLoad()
 
     val xiEoriEnabled: Boolean = true
     val euEoriEnabled: Boolean = false
 
     def normalModeView(): Document = Jsoup.parse(
-      app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
+      app.injector
+        .instanceOf[EoriNumberView]
+        .apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+        .body
     )
-    def checkModeView(): Document = Jsoup.parse(
-      app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
+    def checkModeView(): Document  = Jsoup.parse(
+      app.injector
+        .instanceOf[EoriNumberView]
+        .apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled)
+        .body
     )
   }
 }
-

--- a/test/views/add/EoriNumberViewSpec.scala
+++ b/test/views/add/EoriNumberViewSpec.scala
@@ -39,18 +39,14 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
   "EoriNumberView" should {
     "display the correct guidance in Normal mode with XI Eori Enabled" in new Setup {
       normalModeView().title() mustBe "eoriNumber.title - service.name - site.govuk"
-      normalModeView().getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      normalModeView().getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
+      normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
+      normalModeView().getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text"
 
       val detailsHintElement: Element = normalModeView().getElementById("value-hint-details")
       val hintLabelElement: Elements  = normalModeView().getElementsByClass("govuk-!-margin-top-6")
 
-      detailsHintElement.getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      detailsHintElement.getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
+      detailsHintElement.getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
+      detailsHintElement.getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text"
 
       hintLabelElement.html() mustBe "eoriNumber.hint.xi"
 
@@ -59,81 +55,52 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
 
     "display the correct guidance in Check mode with XI Eori Enabled" in new Setup {
       checkModeView().title() mustBe "eoriNumber.title - service.name - site.govuk"
-      checkModeView().getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      checkModeView().getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
+      checkModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
+      checkModeView().getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text"
 
       val detailsHintElement: Element = normalModeView().getElementById("value-hint-details")
       val hintLabelElement: Elements  = normalModeView().getElementsByClass("govuk-!-margin-top-6")
 
-      detailsHintElement.getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      detailsHintElement.getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
+      detailsHintElement.getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
+      detailsHintElement.getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text"
 
       hintLabelElement.html() mustBe "eoriNumber.hint.xi"
 
       normalModeView().getElementsByTag("button").get(1).html() mustBe "site.saveAndContinue"
     }
 
-    "display the correct guidance in Normal mode with XI Eori Disabled" in new Setup {
-
+    "display the correct guidance in Normal mode with EU Eori Enabled" in new Setup {
       override val xiEoriEnabled = false
+      override val euEoriEnabled = true
 
       override def normalModeView(): Document = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled).body
+        app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
       )
-      override def checkModeView(): Document  = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled).body
+      override def checkModeView(): Document = Jsoup.parse(
+        app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
       )
 
-      normalModeView().title() mustBe "eoriNumber.title - service.name - site.govuk"
-      normalModeView().getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      normalModeView().getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
-
-      val detailsHintElement: Element = normalModeView().getElementById("value-hint-details")
-      val hintLabelElement: Elements  = normalModeView().getElementsByClass("govuk-!-margin-top-6")
-
-      detailsHintElement.getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      detailsHintElement.getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
-
-      hintLabelElement.html() mustBe "eoriNumber.hint"
-
-      normalModeView().getElementsByTag("button").get(1).html() mustBe "site.saveAndContinue"
+      normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
+      normalModeView().getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text.eu"
+      val hintLabelElement: Elements = normalModeView().getElementsByClass("govuk-!-margin-top-6")
+      hintLabelElement.html() mustBe "eoriNumber.hint.eu"
     }
 
-    "display the correct guidance in Check mode with XI Eori Disabled" in new Setup {
+    "display the correct guidance in Normal mode with all Eori Flags Disabled" in new Setup {
       override val xiEoriEnabled = false
+      override val euEoriEnabled = false
 
       override def normalModeView(): Document = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled).body
+        app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
       )
-      override def checkModeView(): Document  = Jsoup.parse(
-        app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled).body
+      override def checkModeView(): Document = Jsoup.parse(
+        app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
       )
 
-      checkModeView().title() mustBe "eoriNumber.title - service.name - site.govuk"
-      checkModeView().getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      checkModeView().getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
-
-      val detailsHintElement: Element = normalModeView().getElementById("value-hint-details")
-      val hintLabelElement: Elements  = normalModeView().getElementsByClass("govuk-!-margin-top-6")
-
-      detailsHintElement.getElementById("value-hint-title").html() mustBe
-        "eoriNumber.details.label"
-      detailsHintElement.getElementsByClass("govuk-body").html() mustBe
-        "eoriNumber.details.text"
-
+      normalModeView().getElementById("value-hint-title").html() mustBe "eoriNumber.details.label"
+      normalModeView().getElementsByClass("govuk-body").html() mustBe "eoriNumber.details.text"
+      val hintLabelElement: Elements = normalModeView().getElementsByClass("govuk-!-margin-top-6")
       hintLabelElement.html() mustBe "eoriNumber.hint"
-
-      normalModeView().getElementsByTag("button").get(1).html() mustBe "site.saveAndContinue"
     }
 
     "when back-link is clicked returns to previous page on Normal Mode" in new Setup {
@@ -153,23 +120,25 @@ class EoriNumberViewSpec extends SpecBase with MockitoSugar {
 
     implicit val csrfRequest: FakeRequest[AnyContentAsEmpty.type] =
       fakeRequest("GET", "/some/resource/path")
-    val app: Application                                          = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
-    implicit val appConfig: FrontendAppConfig                     = app.injector.instanceOf[FrontendAppConfig]
-    implicit val messages: Messages                               = Helpers.stubMessages()
+    val app: Application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+    implicit val appConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
+    implicit val messages: Messages = Helpers.stubMessages()
 
     private val formProvider = new EoriNumberFormProvider(appConfig)
-    val form                 = formProvider()
+    val form = formProvider()
 
     lazy val normalModeBackLinkRoute: Call = controllers.routes.ManageAuthoritiesController.onPageLoad()
-    lazy val checkModeBackLinkRoute: Call  = controllers.add.routes.AuthorisedUserController.onPageLoad()
+    lazy val checkModeBackLinkRoute: Call = controllers.add.routes.AuthorisedUserController.onPageLoad()
 
-    val xiEoriEnabled = true
+    val xiEoriEnabled: Boolean = true
+    val euEoriEnabled: Boolean = false
 
     def normalModeView(): Document = Jsoup.parse(
-      app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled).body
+      app.injector.instanceOf[EoriNumberView].apply(form, NormalMode, normalModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
     )
-    def checkModeView(): Document  = Jsoup.parse(
-      app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled).body
+    def checkModeView(): Document = Jsoup.parse(
+      app.injector.instanceOf[EoriNumberView].apply(form, CheckMode, checkModeBackLinkRoute, xiEoriEnabled, euEoriEnabled).body
     )
   }
 }
+


### PR DESCRIPTION
[Tasks]
- Simplified conditional logic in `EoriNumberView` by collapsing `xiEoriEnabled` and `euEoriEnabled` into a single (labelHintKey, detailsTextKey) pair
- Added translations for EuEori
- Removed redundant `(request, messages, appConfig)` parameter group from `EoriNumberController` view calls, they are already provided implicitly by the controller method context.
- Updated unit tests
