### PR TITLE
[MMCA-5247] - Use of new endpoint to delete notification in customs-manage-authorities-frontend

### DIFF
--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -119,8 +119,8 @@ class CustomsFinancialsConnector @Inject() (
       .execute[CompanyName]
   }
 
-  def deleteNotification(eori: String, fileRole: FileRole)(implicit hc: HeaderCarrier): Future[Boolean] = {
-    val deleteNotificationUrl = s"$baseApiUrl/eori/$eori/notifications/$fileRole"
+  def deleteNotification(fileRole: FileRole)(implicit hc: HeaderCarrier): Future[Boolean] = {
+    val deleteNotificationUrl = s"$baseApiUrl/eori/notifications/$fileRole"
     metricsReporterService.withResponseTimeLogging("customs-financials-api.delete.notification") {
       httpClient
         .delete(url"$deleteNotificationUrl")

--- a/app/controllers/ManageAuthoritiesController.scala
+++ b/app/controllers/ManageAuthoritiesController.scala
@@ -64,7 +64,7 @@ class ManageAuthoritiesController @Inject() (
 
   def onPageLoad: Action[AnyContent] = (identify andThen checkEmailIsVerified).async { implicit request =>
 
-    customsFinancialsConnector.deleteNotification(request.eoriNumber, StandingAuthority)
+    customsFinancialsConnector.deleteNotification(StandingAuthority)
 
     val returnToUrl = appConfig.manageAuthoritiesServiceUrl + routes.ManageAuthoritiesController.onPageLoad().url
 

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -304,11 +304,11 @@ class CustomsFinancialsConnectorSpec
     running(app) {
 
       server.stubFor(
-        delete(urlEqualTo(s"/customs-financials-api/eori/$eoriNumber/notifications/${FileRole.StandingAuthority}"))
+        delete(urlEqualTo(s"/customs-financials-api/eori/notifications/${FileRole.StandingAuthority}"))
           .willReturn(ok())
       )
 
-      val result = connector.deleteNotification(eoriNumber, FileRole.StandingAuthority)(hc).futureValue
+      val result = connector.deleteNotification(FileRole.StandingAuthority)(hc).futureValue
       result mustBe true
     }
   }

--- a/test/controllers/ManageAuthoritiesControllerSpec.scala
+++ b/test/controllers/ManageAuthoritiesControllerSpec.scala
@@ -59,7 +59,7 @@ class ManageAuthoritiesControllerSpec extends SpecBase with MockitoSugar with Da
           val request = fakeRequest(GET, manageAuthoritiesRoute)
           await(route(application, request).value)
 
-          verify(mockCustomsFinancialsConnector).deleteNotification(any, any)(any)
+          verify(mockCustomsFinancialsConnector).deleteNotification(any)(any)
         }
       }
     }


### PR DESCRIPTION
- [x] Update endpoint in customsFinancialsConnector, def deleteNotification and remove eori param
- [x] Remove eori from ManageAuthoritiesController, def onPageLoad
- [x] Update tests
- [x] Test correct endpoint is called using UI