### PR TITLE
MMCA-5249: Updated Validate Connector with new endpoint

### DIFF
--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -95,7 +95,8 @@ class CustomsFinancialsConnector @Inject() (
   }
 
   def validateEori(eori: String)(implicit hc: HeaderCarrier): Future[Either[ErrorResponse, Boolean]] = {
-    val validateEoriUrl = s"$baseApiUrl/eori/$eori/validate"
+    // val revokeAccountAuthoritiesUrl = s"$baseApiUrl/$eori/account-authorities/revoke"
+    val validateEoriUrl = s"$baseApiUrl/eori/validate"
     httpClient
       .get(url"$validateEoriUrl")
       .execute[HttpResponse]

--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -95,7 +95,7 @@ class CustomsFinancialsConnector @Inject() (
   }
 
   def validateEori(eori: String)(implicit hc: HeaderCarrier): Future[Either[ErrorResponse, Boolean]] = {
-    val validateEoriUrl = s"$baseApiUrl/eori/validate"
+    val validateEoriUrl      = s"$baseApiUrl/eori/validate"
     val request: EoriRequest = EoriRequest(eori)
     httpClient
       .post(url"$validateEoriUrl")

--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -95,7 +95,6 @@ class CustomsFinancialsConnector @Inject() (
   }
 
   def validateEori(eori: String)(implicit hc: HeaderCarrier): Future[Either[ErrorResponse, Boolean]] = {
-    // val revokeAccountAuthoritiesUrl = s"$baseApiUrl/$eori/account-authorities/revoke"
     val validateEoriUrl = s"$baseApiUrl/eori/validate"
     httpClient
       .get(url"$validateEoriUrl")

--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -97,6 +97,7 @@ class CustomsFinancialsConnector @Inject() (
   def validateEori(eori: String)(implicit hc: HeaderCarrier): Future[Either[ErrorResponse, Boolean]] = {
     val validateEoriUrl      = s"$baseApiUrl/eori/validate"
     val request: EoriRequest = EoriRequest(eori)
+
     httpClient
       .post(url"$validateEoriUrl")
       .withBody(request)

--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -96,8 +96,10 @@ class CustomsFinancialsConnector @Inject() (
 
   def validateEori(eori: String)(implicit hc: HeaderCarrier): Future[Either[ErrorResponse, Boolean]] = {
     val validateEoriUrl = s"$baseApiUrl/eori/validate"
+    val request: EoriRequest = EoriRequest(eori)
     httpClient
-      .get(url"$validateEoriUrl")
+      .post(url"$validateEoriUrl")
+      .withBody(request)
       .execute[HttpResponse]
       .map { response =>
         response.status match {

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -243,7 +243,7 @@ class CustomsFinancialsConnectorSpec
 
         server.stubFor(
           post(urlEqualTo("/customs-financials-api/eori/validate"))
-          .withRequestBody(equalToJson("""{"eori": "121312"}"""))
+            .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(ok())
         )
 
@@ -259,7 +259,7 @@ class CustomsFinancialsConnectorSpec
 
         server.stubFor(
           post(urlEqualTo("/customs-financials-api/eori/validate"))
-          .withRequestBody(equalToJson("""{"eori": "121312"}"""))
+            .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(notFound())
         )
 
@@ -275,7 +275,7 @@ class CustomsFinancialsConnectorSpec
 
         server.stubFor(
           post(urlEqualTo("/customs-financials-api/eori/validate"))
-          .withRequestBody(equalToJson("""{"eori": "121312"}"""))
+            .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(serverError())
         )
 
@@ -297,6 +297,7 @@ class CustomsFinancialsConnectorSpec
             .willReturn(ok(json))
         )
         val result = connector.retrieveEoriCompanyName().futureValue
+
         result.name mustBe Some("ABCD")
       }
     }

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -242,12 +242,13 @@ class CustomsFinancialsConnectorSpec
       running(app) {
 
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/eori/validate"))
+          post(urlEqualTo("/customs-financials-api/eori/validate"))
+          .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(ok())
         )
 
         val result = connector.validateEori(eoriNumber).futureValue
-
+        
         result mustBe Right(true)
       }
     }
@@ -257,7 +258,8 @@ class CustomsFinancialsConnectorSpec
       running(app) {
 
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/eori/121312/validate"))
+          post(urlEqualTo("/customs-financials-api/eori/validate"))
+          .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(notFound())
         )
 
@@ -272,7 +274,8 @@ class CustomsFinancialsConnectorSpec
       running(app) {
 
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/eori/validate"))
+          post(urlEqualTo("/customs-financials-api/eori/validate"))
+          .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(serverError())
         )
 

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -242,7 +242,7 @@ class CustomsFinancialsConnectorSpec
       running(app) {
 
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/eori/121312/validate"))
+          get(urlEqualTo("/customs-financials-api/eori/validate"))
             .willReturn(ok())
         )
 
@@ -272,7 +272,7 @@ class CustomsFinancialsConnectorSpec
       running(app) {
 
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/eori/121312/validate"))
+          get(urlEqualTo("/customs-financials-api/eori/validate"))
             .willReturn(serverError())
         )
 

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -248,7 +248,7 @@ class CustomsFinancialsConnectorSpec
         )
 
         val result = connector.validateEori(eoriNumber).futureValue
-        
+
         result mustBe Right(true)
       }
     }

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -297,7 +297,6 @@ class CustomsFinancialsConnectorSpec
             .willReturn(ok(json))
         )
         val result = connector.retrieveEoriCompanyName().futureValue
-
         result.name mustBe Some("ABCD")
       }
     }


### PR DESCRIPTION
Update Validate Connector with new endpoint

A new endpoint has been created in customs-financials-api so the eori is carried in the request body to avoid exposing the eori in the url. The connector in custom-manage-authorities-frontend is now updated so it calls the new endpoint.