### PR TITLE
MMCA 5250 - Update Get / Grant / Revoke Endpoints in customs-manage-authorities-frontend

### DIFF
--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -64,9 +64,10 @@ class CustomsFinancialsConnector @Inject() (
 
   def retrieveAccountAuthorities(eori: String)(implicit hc: HeaderCarrier): Future[Seq[AccountWithAuthorities]] = {
     val retrieveAccountAuthoritiesUrl = s"$baseApiUrl/account-authorities"
-    val request: EoriRequest = EoriRequest(eori)
+    val request: EoriRequest          = EoriRequest(eori)
+
     httpClient
-      .get(url"$retrieveAccountAuthoritiesUrl")
+      .post(url"$retrieveAccountAuthoritiesUrl")
       .withBody(request)
       .execute[Seq[AccountWithAuthorities]]
   }

--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -62,11 +62,12 @@ class CustomsFinancialsConnector @Inject() (
       .map(_.toCdsAccounts(eori))
   }
 
-  def retrieveAccountAuthorities()(implicit hc: HeaderCarrier): Future[Seq[AccountWithAuthorities]] = {
+  def retrieveAccountAuthorities(eori: String)(implicit hc: HeaderCarrier): Future[Seq[AccountWithAuthorities]] = {
     val retrieveAccountAuthoritiesUrl = s"$baseApiUrl/account-authorities"
-
+    val request: EoriRequest = EoriRequest(eori)
     httpClient
       .get(url"$retrieveAccountAuthoritiesUrl")
+      .withBody(request)
       .execute[Seq[AccountWithAuthorities]]
   }
 

--- a/app/connectors/CustomsFinancialsConnector.scala
+++ b/app/connectors/CustomsFinancialsConnector.scala
@@ -28,7 +28,6 @@ import play.mvc.Http.Status
 import services.MetricsReporterService
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
-import utils.StringUtils.emptyString
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException, StringContextOps}
 
 import javax.inject.Inject
@@ -63,17 +62,19 @@ class CustomsFinancialsConnector @Inject() (
       .map(_.toCdsAccounts(eori))
   }
 
-  def retrieveAccountAuthorities(eori: String)(implicit hc: HeaderCarrier): Future[Seq[AccountWithAuthorities]] = {
-    val retrieveAccountAuthoritiesUrl = s"$baseApiUrl/$eori/account-authorities"
+  def retrieveAccountAuthorities()(implicit hc: HeaderCarrier): Future[Seq[AccountWithAuthorities]] = {
+    val retrieveAccountAuthoritiesUrl = s"$baseApiUrl/account-authorities"
+
     httpClient
       .get(url"$retrieveAccountAuthoritiesUrl")
       .execute[Seq[AccountWithAuthorities]]
   }
 
-  def grantAccountAuthorities(addAuthorityRequest: AddAuthorityRequest, eori: String = emptyString)(implicit
+  def grantAccountAuthorities(addAuthorityRequest: AddAuthorityRequest)(implicit
     hc: HeaderCarrier
   ): Future[Boolean] = {
-    val grantAccountAuthoritiesUrl = s"$baseApiUrl/$eori/account-authorities/grant"
+    val grantAccountAuthoritiesUrl = s"$baseApiUrl/account-authorities/grant"
+
     httpClient
       .post(url"$grantAccountAuthoritiesUrl")
       .withBody(addAuthorityRequest)
@@ -82,10 +83,11 @@ class CustomsFinancialsConnector @Inject() (
       .recover { case _ => false }
   }
 
-  def revokeAccountAuthorities(revokeAuthorityRequest: RevokeAuthorityRequest, eori: String = emptyString)(implicit
+  def revokeAccountAuthorities(revokeAuthorityRequest: RevokeAuthorityRequest)(implicit
     hc: HeaderCarrier
   ): Future[Boolean] = {
-    val revokeAccountAuthoritiesUrl = s"$baseApiUrl/$eori/account-authorities/revoke"
+    val revokeAccountAuthoritiesUrl = s"$baseApiUrl/account-authorities/revoke"
+
     httpClient
       .post(url"$revokeAccountAuthoritiesUrl")
       .withBody(revokeAuthorityRequest)

--- a/app/controllers/add/AuthorisedUserController.scala
+++ b/app/controllers/add/AuthorisedUserController.scala
@@ -80,10 +80,10 @@ class AuthorisedUserController @Inject() (
 
   private def doSubmission(userAnswers: UserAnswers, xiEori: String, eori: String)(implicit
     hc: HeaderCarrier
-  ): Future[Result] =
+  ): Future[Result] = {
     val enteredEori = (userAnswers.data \ "eoriNumber" \ "eori").as[String]
     val ownerEori   = if (enteredEori.startsWith(nIEORIPrefix) && eori.startsWith(gbEORIPrefix)) xiEori else eori
-    
+
     addAuthorityValidationService
       .validate(userAnswers, ownerEori)
       .fold(
@@ -98,6 +98,7 @@ class AuthorisedUserController @Inject() (
           }
         }
       }
+  }
 
   private def processPayloadForLinkedXiAndGbEori(
     userAnswers: UserAnswers,
@@ -109,8 +110,7 @@ class AuthorisedUserController @Inject() (
 
     for {
       result <- Future.sequence(grantAccAuthRequests.map { req =>
-                  val payloadWithOwnerEori = req.payload.copy(ownerEori = req.ownerEori)
-                  connector.grantAccountAuthorities(payloadWithOwnerEori)
+                  connector.grantAccountAuthorities(req.payload.copy(ownerEori = req.ownerEori))
                 })
     } yield
       if (result.contains(false)) {

--- a/app/controllers/add/AuthorisedUserController.scala
+++ b/app/controllers/add/AuthorisedUserController.scala
@@ -92,8 +92,7 @@ class AuthorisedUserController @Inject() (
         if (enteredEori.startsWith(nIEORIPrefix) && eori.startsWith(gbEORIPrefix)) {
           processPayloadForLinkedXiAndGbEori(userAnswers, xiEori, eori, payload)
         } else {
-          val payloadWithOwnerEori = payload.copy(ownerEori = ownerEori)
-          connector.grantAccountAuthorities(payloadWithOwnerEori).map {
+          connector.grantAccountAuthorities(payload).map {
             case true  => Redirect(navigator.nextPage(AuthorisedUserPage, NormalMode, userAnswers))
             case false => errorPage(("Add authority request submission to backend failed", payload))
           }

--- a/app/controllers/edit/EditCheckYourAnswersController.scala
+++ b/app/controllers/edit/EditCheckYourAnswersController.scala
@@ -115,7 +115,14 @@ class EditCheckYourAnswersController @Inject() (
 
     val ownerEori = if (authorisedEori.startsWith(nIEORIPrefix)) xiEori else eori
 
-    editAuthorityValidationService.validate(userAnswers, accountId, authorityId, authorisedEori, account, ownerEori) match {
+    editAuthorityValidationService.validate(
+      userAnswers,
+      accountId,
+      authorityId,
+      authorisedEori,
+      account,
+      ownerEori
+    ) match {
       case Right(payload) =>
         if (authorisedEori.startsWith(nIEORIPrefix)) {
           processPayloadForXIEori(userAnswers, xiEori, eori, payload, accountId, authorityId)
@@ -150,8 +157,7 @@ class EditCheckYourAnswersController @Inject() (
 
     for {
       result <- Future.sequence(grantAccAuthRequests.map { req =>
-                  val payloadWithOwnerEori = req.payload.copy(ownerEori = req.ownerEori)
-                  connector.grantAccountAuthorities(payloadWithOwnerEori)
+                  connector.grantAccountAuthorities(req.payload.copy(ownerEori = req.ownerEori))
                 })
     } yield
       if (result.contains(false)) {

--- a/app/controllers/edit/EditCheckYourAnswersController.scala
+++ b/app/controllers/edit/EditCheckYourAnswersController.scala
@@ -120,8 +120,7 @@ class EditCheckYourAnswersController @Inject() (
         if (authorisedEori.startsWith(nIEORIPrefix)) {
           processPayloadForXIEori(userAnswers, xiEori, eori, payload, accountId, authorityId)
         } else {
-          val payloadWithOwnerEori = payload.copy(ownerEori = ownerEori)
-          connector.grantAccountAuthorities(payloadWithOwnerEori).map {
+          connector.grantAccountAuthorities(payload).map {
             case true  =>
               Redirect(navigator.nextPage(EditCheckYourAnswersPage(accountId, authorityId), NormalMode, userAnswers))
             case false =>

--- a/app/controllers/remove/RemoveCheckYourAnswers.scala
+++ b/app/controllers/remove/RemoveCheckYourAnswers.scala
@@ -94,7 +94,7 @@ class RemoveCheckYourAnswers @Inject() (
                             xiEori.getOrElse(emptyString),
                             request.eoriNumber
                           )
-                          
+
                           val revokeRequest = RevokeAuthorityRequest(
                             account.accountNumber,
                             account.accountType,
@@ -123,9 +123,9 @@ class RemoveCheckYourAnswers @Inject() (
     eori: String
   )(implicit hc: HeaderCarrier): Future[Result] = {
 
-    val ownerEori = ownerEoriForAccountType(revokeRequest.accountType, revokeRequest.authorisedEori, xiEori, eori)
+    val ownerEori            = ownerEoriForAccountType(revokeRequest.accountType, revokeRequest.authorisedEori, xiEori, eori)
     val payloadWithOwnerEori = revokeRequest.copy(ownerEori = ownerEori)
-    
+
     customsFinancialsConnector.revokeAccountAuthorities(payloadWithOwnerEori).map {
       case true  => Redirect(routes.RemoveConfirmationController.onPageLoad(accountId, authorityId))
       case false => errorPage(SubmissionError)

--- a/app/controllers/remove/RemoveCheckYourAnswers.scala
+++ b/app/controllers/remove/RemoveCheckYourAnswers.scala
@@ -88,11 +88,19 @@ class RemoveCheckYourAnswers @Inject() (
             result <- request.userAnswers
                         .get(RemoveAuthorisedUserPage(accountId, authorityId))
                         .map { authorisedUser =>
+                          val ownerEori = ownerEoriForAccountType(
+                            account.accountType,
+                            authority.authorisedEori,
+                            xiEori.getOrElse(emptyString),
+                            request.eoriNumber
+                          )
+                          
                           val revokeRequest = RevokeAuthorityRequest(
                             account.accountNumber,
                             account.accountType,
                             authority.authorisedEori,
-                            authorisedUser
+                            authorisedUser,
+                            ownerEori
                           )
                           doSubmission(
                             revokeRequest,
@@ -116,8 +124,9 @@ class RemoveCheckYourAnswers @Inject() (
   )(implicit hc: HeaderCarrier): Future[Result] = {
 
     val ownerEori = ownerEoriForAccountType(revokeRequest.accountType, revokeRequest.authorisedEori, xiEori, eori)
-
-    customsFinancialsConnector.revokeAccountAuthorities(revokeRequest, ownerEori).map {
+    val payloadWithOwnerEori = revokeRequest.copy(ownerEori = ownerEori)
+    
+    customsFinancialsConnector.revokeAccountAuthorities(payloadWithOwnerEori).map {
       case true  => Redirect(routes.RemoveConfirmationController.onPageLoad(accountId, authorityId))
       case false => errorPage(SubmissionError)
     }

--- a/app/models/requests/ManageAuthorityRequests.scala
+++ b/app/models/requests/ManageAuthorityRequests.scala
@@ -35,7 +35,8 @@ case class AddAuthorityRequest(
   accounts: Accounts,
   authority: StandingAuthority,
   authorisedUser: AuthorisedUser,
-  editRequest: Boolean = false
+  editRequest: Boolean = false,
+  ownerEori: String
 )
 
 object AddAuthorityRequest {
@@ -46,7 +47,8 @@ case class RevokeAuthorityRequest(
   accountNumber: String,
   accountType: AccountType,
   authorisedEori: String,
-  authorisedUser: AuthorisedUser
+  authorisedUser: AuthorisedUser,
+  ownerEori: String
 )
 
 object RevokeAuthorityRequest {

--- a/app/services/AuthoritiesCacheService.scala
+++ b/app/services/AuthoritiesCacheService.scala
@@ -33,7 +33,7 @@ class AuthoritiesCacheService @Inject() (repository: AuthoritiesRepository, conn
     hc: HeaderCarrier
   ): Future[AuthoritiesWithId] = {
     val authorities = for {
-      a <- Future.sequence(eoriList.map(eachEori => connector.retrieveAccountAuthorities(eachEori)))
+      a <- Future.sequence(eoriList.map(eachEori => connector.retrieveAccountAuthorities()))
     } yield a.flatten
       .groupBy(_.accountNumber)
       .map { case (accountNumber, accountsWithSameAccountNumber) =>

--- a/app/services/AuthoritiesCacheService.scala
+++ b/app/services/AuthoritiesCacheService.scala
@@ -33,7 +33,7 @@ class AuthoritiesCacheService @Inject() (repository: AuthoritiesRepository, conn
     hc: HeaderCarrier
   ): Future[AuthoritiesWithId] = {
     val authorities = for {
-      a <- Future.sequence(eoriList.map(eachEori => connector.retrieveAccountAuthorities()))
+      a <- Future.sequence(eoriList.map(eachEori => connector.retrieveAccountAuthorities(eachEori)))
     } yield a.flatten
       .groupBy(_.accountNumber)
       .map { case (accountNumber, accountsWithSameAccountNumber) =>

--- a/app/services/add/AddAuthorityValidationService.scala
+++ b/app/services/add/AddAuthorityValidationService.scala
@@ -22,13 +22,13 @@ import models.requests.AddAuthorityRequest
 
 class AddAuthorityValidationService @Inject() (cyaValidationService: CheckYourAnswersValidationService) {
 
-  def validate(userAnswers: UserAnswers): Option[AddAuthorityRequest] =
+  def validate(userAnswers: UserAnswers, ownerEori: String): Option[AddAuthorityRequest] =
     for {
       (accounts, standingAuthority, authorisedUser) <- cyaValidationService.validate(userAnswers)
     } yield AddAuthorityRequest(
       accounts,
       standingAuthority,
-      authorisedUser
+      authorisedUser,
+      ownerEori = ownerEori
     )
-
 }

--- a/app/services/edit/EditAuthorityValidationService.scala
+++ b/app/services/edit/EditAuthorityValidationService.scala
@@ -31,7 +31,8 @@ class EditAuthorityValidationService @Inject() (editCyaValidationService: EditCh
     accountId: String,
     authorityId: String,
     authorisedEori: String,
-    account: AccountWithAuthoritiesWithId
+    account: AccountWithAuthoritiesWithId,
+    ownerEori: String
   ): Either[ErrorResponse, AddAuthorityRequest] = {
 
     val maybeAccounts = for {
@@ -40,7 +41,7 @@ class EditAuthorityValidationService @Inject() (editCyaValidationService: EditCh
 
       accounts = checkAndRetrieveAccounts(account)
     } yield accounts match {
-      case Right(value) => Right(AddAuthorityRequest(value, standingAuthority, authorisedUser, editRequest = true))
+      case Right(value) => Right(AddAuthorityRequest(value, standingAuthority, authorisedUser, editRequest = true, ownerEori))
       case Left(error)  => Left(error)
     }
 

--- a/app/services/edit/EditAuthorityValidationService.scala
+++ b/app/services/edit/EditAuthorityValidationService.scala
@@ -41,7 +41,8 @@ class EditAuthorityValidationService @Inject() (editCyaValidationService: EditCh
 
       accounts = checkAndRetrieveAccounts(account)
     } yield accounts match {
-      case Right(value) => Right(AddAuthorityRequest(value, standingAuthority, authorisedUser, editRequest = true, ownerEori))
+      case Right(value) =>
+        Right(AddAuthorityRequest(value, standingAuthority, authorisedUser, editRequest = true, ownerEori))
       case Left(error)  => Left(error)
     }
 

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -30,6 +30,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.running
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.WireMockHelper
+import utils.TestData.EORI_NUMBER
 
 import java.time.LocalDate
 
@@ -52,7 +53,7 @@ class CustomsFinancialsConnectorSpec
 
   ".retrieveAccounts" must {
     "return accounts" in new Setup {
-      val response =
+      val response: String =
         """
           |{
           |  "accountsAndBalancesResponse": {
@@ -83,7 +84,7 @@ class CustomsFinancialsConnectorSpec
           |}
           |""".stripMargin
 
-      val expected = CDSAccounts(
+      val expected: CDSAccounts = CDSAccounts(
         "GB123456789012",
         List(CashAccount("12345", "GB123456789012", AccountStatusOpen, CDSCashBalance(Some(100.00))))
       )
@@ -102,7 +103,7 @@ class CustomsFinancialsConnectorSpec
 
   ".retrieveAccountAuthorities" must {
     "return account authorities" in new Setup {
-      val accountAuthorities = Seq(
+      val accountAuthorities: Seq[AccountWithAuthorities] = Seq(
         AccountWithAuthorities(
           domain.CdsCashAccount,
           "12345",
@@ -111,7 +112,7 @@ class CustomsFinancialsConnectorSpec
         )
       )
 
-      val response =
+      val response: String =
         """
           |[
           |   {
@@ -129,7 +130,7 @@ class CustomsFinancialsConnectorSpec
             .willReturn(ok(response))
         )
 
-        val result = connector.retrieveAccountAuthorities((): Unit).futureValue
+        val result = connector.retrieveAccountAuthorities(eoriNumber).futureValue
 
         result mustBe accountAuthorities
       }
@@ -150,7 +151,9 @@ class CustomsFinancialsConnectorSpec
         Option(LocalDate.now().plusDays(1)),
         viewBalance = true
       ),
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      true,
+      EORI_NUMBER
     )
 
     "return success response" in new Setup {
@@ -196,7 +199,8 @@ class CustomsFinancialsConnectorSpec
       "12345",
       domain.CdsCashAccount,
       "authorisedEori",
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      EORI_NUMBER
     )
 
     "return success response" in new Setup {

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -127,6 +127,7 @@ class CustomsFinancialsConnectorSpec
       running(app) {
         server.stubFor(
           post(urlEqualTo("/customs-financials-api/account-authorities"))
+            .withRequestBody(equalToJson("""{"eori": "121312"}"""))
             .willReturn(ok(response))
         )
 

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -126,7 +126,7 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/account-authorities"))
+          post(urlEqualTo("/customs-financials-api/account-authorities"))
             .willReturn(ok(response))
         )
 

--- a/test/connectors/CustomsFinancialsConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialsConnectorSpec.scala
@@ -125,7 +125,7 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          get(urlEqualTo("/customs-financials-api/()/account-authorities"))
+          get(urlEqualTo("/customs-financials-api/account-authorities"))
             .willReturn(ok(response))
         )
 
@@ -157,10 +157,10 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          post(urlEqualTo("/customs-financials-api/someEori/account-authorities/grant"))
+          post(urlEqualTo("/customs-financials-api/account-authorities/grant"))
             .willReturn(noContent())
         )
-        val result = connector.grantAccountAuthorities(request, "someEori").futureValue
+        val result = connector.grantAccountAuthorities(request).futureValue
         result mustBe true
       }
     }
@@ -169,10 +169,10 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          post(urlEqualTo("/customs-financials-api/someEori/account-authorities/grant"))
+          post(urlEqualTo("/customs-financials-api/account-authorities/grant"))
             .willReturn(serverError())
         )
-        val result = connector.grantAccountAuthorities(request, "someEori").futureValue
+        val result = connector.grantAccountAuthorities(request).futureValue
         result mustBe false
       }
     }
@@ -181,10 +181,10 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          post(urlEqualTo("/customs-financials-api/someEori/account-authorities/grant"))
+          post(urlEqualTo("/customs-financials-api/account-authorities/grant"))
             .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK))
         )
-        val result = connector.grantAccountAuthorities(request, "someEori").futureValue
+        val result = connector.grantAccountAuthorities(request).futureValue
         result mustBe false
       }
     }
@@ -203,10 +203,10 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          post(urlEqualTo("/customs-financials-api/someEori/account-authorities/revoke"))
+          post(urlEqualTo("/customs-financials-api/account-authorities/revoke"))
             .willReturn(noContent())
         )
-        val result = connector.revokeAccountAuthorities(request, "someEori").futureValue
+        val result = connector.revokeAccountAuthorities(request).futureValue
         result mustBe true
       }
     }
@@ -215,10 +215,10 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          post(urlEqualTo("/customs-financials-api/someEori/account-authorities/revoke"))
+          post(urlEqualTo("/customs-financials-api/account-authorities/revoke"))
             .willReturn(serverError())
         )
-        val result = connector.revokeAccountAuthorities(request, "someEori").futureValue
+        val result = connector.revokeAccountAuthorities(request).futureValue
         result mustBe false
       }
     }
@@ -227,10 +227,10 @@ class CustomsFinancialsConnectorSpec
 
       running(app) {
         server.stubFor(
-          post(urlEqualTo("/customs-financials-api/someEori/account-authorities/revoke"))
+          post(urlEqualTo("/customs-financials-api/account-authorities/revoke"))
             .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK))
         )
-        val result = connector.revokeAccountAuthorities(request, "someEori").futureValue
+        val result = connector.revokeAccountAuthorities(request).futureValue
         result mustBe false
       }
     }

--- a/test/controllers/PackageSpec.scala
+++ b/test/controllers/PackageSpec.scala
@@ -53,31 +53,41 @@ class PackageSpec extends SpecBase {
     val authReq: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(Some("12345"), Seq("67890"), Some("12345678")),
       StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      editRequest = false,
+      gbEori
     )
 
     val authReqWithDDAccountsOnly: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(None, Seq("67890"), None),
       StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      editRequest = false,
+      gbEori
     )
 
     val authReqWithNoDDAccounts: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(Some("12345"), Seq(), None),
       StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      editRequest = false,
+      gbEori
     )
 
     val authReqForCashAndGuaranteeAccount: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(Some("12345"), Seq(), Some("12345678")),
       StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      editRequest = false,
+      gbEori
     )
 
     val authReqForDDAccount: AddAuthorityRequest = AddAuthorityRequest(
       Accounts(None, Seq("67890"), None),
       StandingAuthority("GB123456789012", localDate, Option(toLocalDate), viewBalance = true),
-      AuthorisedUser("name", "job")
+      AuthorisedUser("name", "job"),
+      editRequest = false,
+      gbEori
     )
   }
 }

--- a/test/controllers/add/AuthorisedUserControllerSpec.scala
+++ b/test/controllers/add/AuthorisedUserControllerSpec.scala
@@ -40,7 +40,7 @@ import services.DateTimeService
 import services.add.CheckYourAnswersValidationService
 import utils.StringUtils.emptyString
 import views.html.add.AuthorisedUserView
-import org.mockito.ArgumentMatchers.{eq => eqMatcher, any}
+import org.mockito.ArgumentMatchers.{any, eq => eqMatcher}
 
 import java.time.{LocalDate, LocalDateTime}
 import scala.concurrent.Future
@@ -331,9 +331,9 @@ class AuthorisedUserControllerSpec extends SpecBase with MockitoSugar {
     val mockConnector: CustomsFinancialsConnector         = mock[CustomsFinancialsConnector]
     val mockDataStoreConnector: CustomsDataStoreConnector = mock[CustomsDataStoreConnector]
 
-    val gbEori                 = "GB123456789012"
-    val xiEori                 = "XI9876543210000"
-    val euEori                 = "DE9876543210000"
+    val gbEori = "GB123456789012"
+    val xiEori = "XI9876543210000"
+    val euEori = "DE9876543210000"
 
     val accountsString: String =
       AccountWithAuthorities(CdsCashAccount, "12345", Some(AccountStatusOpen), Seq.empty).toString

--- a/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
@@ -231,7 +231,9 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
           )
 
         when(
-          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithGbOwnerCA))(any())
+          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithGbOwnerCA))(
+            any()
+          )
         )
           .thenReturn(Future.successful(true))
 
@@ -268,7 +270,9 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
           )
 
         when(
-          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithGbOwnerGG))(any())
+          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithGbOwnerGG))(
+            any()
+          )
         )
           .thenReturn(Future.successful(true))
 

--- a/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
+++ b/test/controllers/remove/RemoveCheckYourAnswersControllerSpec.scala
@@ -19,8 +19,9 @@ package controllers.remove
 import base.SpecBase
 import connectors.{CustomsDataStoreConnector, CustomsFinancialsConnector}
 import models.UserAnswers
-import models.domain._
-import org.mockito.ArgumentMatchers.any
+import models.domain.*
+import models.requests.RevokeAuthorityRequest
+import org.mockito.ArgumentMatchers.{any, eq => eqMatcher}
 import org.mockito.Mockito.{verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatestplus.mockito.MockitoSugar
@@ -28,7 +29,7 @@ import pages.remove.RemoveAuthorisedUserPage
 import play.api.inject.guice.GuiceableModule
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import play.api.{Application, inject}
 import services.{AccountAndAuthority, AuthoritiesCacheService, NoAccount, NoAuthority}
 import utils.StringUtils.emptyString
@@ -154,7 +155,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
       when(mockAuthoritiesCacheService.getAccountAndAuthority(any(), any(), any())(any()))
         .thenReturn(Future.successful(Right(AccountAndAuthority(accountsWithAuthoritiesWithId, standingAuthority))))
 
-      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), any())(any()))
+      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any())(any()))
         .thenReturn(Future.successful(false))
 
       running(app) {
@@ -173,7 +174,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
       when(mockAuthoritiesCacheService.getAccountAndAuthority(any(), any(), any())(any()))
         .thenReturn(Future.successful(Right(AccountAndAuthority(accountsWithAuthoritiesWithId, standingAuthority))))
 
-      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), any())(any()))
+      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any())(any()))
         .thenReturn(Future.successful(true))
 
       running(app) {
@@ -198,7 +199,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
       when(mockAuthoritiesCacheService.getAccountAndAuthority(any(), any(), any())(any()))
         .thenReturn(Future.successful(Right(AccountAndAuthority(accountsWithAuthoritiesWithId, standingAuthority))))
 
-      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), any())(any()))
+      when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any())(any()))
         .thenReturn(Future.successful(true))
 
       running(app) {
@@ -208,7 +209,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
         redirectLocation(result).value mustBe
           controllers.remove.routes.RemoveConfirmationController.onPageLoad("a", "b").url
         verify(mockCustomsFinancialsConnector, Mockito.times(1))
-          .revokeAccountAuthorities(any(), ArgumentMatchers.eq(euEori))(any)
+          .revokeAccountAuthorities(eqMatcher(euRevokeAuthorityRequest))(any)
       }
     }
 
@@ -229,7 +230,9 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
             Future.successful(Right(AccountAndAuthority(accountsWithAuthoritiesWithId, standingAuthorityWithXIEori)))
           )
 
-        when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), ArgumentMatchers.eq(gbEori))(any()))
+        when(
+          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithGbOwnerCA))(any())
+        )
           .thenReturn(Future.successful(true))
 
         when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future(Option(xiEori)))
@@ -241,7 +244,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
           redirectLocation(result).value mustBe
             controllers.remove.routes.RemoveConfirmationController.onPageLoad("a", "b").url
 
-          verify(mockCustomsFinancialsConnector, Mockito.times(1)).revokeAccountAuthorities(any, any)(any)
+          verify(mockCustomsFinancialsConnector, Mockito.times(1)).revokeAccountAuthorities(any)(any)
         }
       }
 
@@ -264,7 +267,9 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
             )
           )
 
-        when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), ArgumentMatchers.eq(gbEori))(any()))
+        when(
+          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithGbOwnerGG))(any())
+        )
           .thenReturn(Future.successful(true))
 
         when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future(Option(xiEori)))
@@ -276,7 +281,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
           redirectLocation(result).value mustBe
             controllers.remove.routes.RemoveConfirmationController.onPageLoad("a", "b").url
 
-          verify(mockCustomsFinancialsConnector, Mockito.times(1)).revokeAccountAuthorities(any, any)(any)
+          verify(mockCustomsFinancialsConnector, Mockito.times(1)).revokeAccountAuthorities(any)(any)
         }
       }
 
@@ -300,7 +305,9 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
             )
           )
 
-        when(mockCustomsFinancialsConnector.revokeAccountAuthorities(any(), ArgumentMatchers.eq(xiEori))(any()))
+        when(
+          mockCustomsFinancialsConnector.revokeAccountAuthorities(eqMatcher(xiRevokeAuthorityRequestWithXiOwner))(any())
+        )
           .thenReturn(Future.successful(true))
 
         when(mockDataStoreConnector.getXiEori(any)(any)).thenReturn(Future(Option(xiEori)))
@@ -312,7 +319,7 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
           redirectLocation(result).value mustBe
             controllers.remove.routes.RemoveConfirmationController.onPageLoad("a", "b").url
 
-          verify(mockCustomsFinancialsConnector, Mockito.times(1)).revokeAccountAuthorities(any, any)(any)
+          verify(mockCustomsFinancialsConnector, Mockito.times(1)).revokeAccountAuthorities(any)(any)
         }
       }
   }
@@ -328,11 +335,45 @@ class RemoveCheckYourAnswersControllerSpec extends SpecBase with MockitoSugar {
     val gbEori                   = "GB123456789012"
     val xiEori                   = "XI123456789012"
     val euEori                   = "DE123456789012"
+    val eori                     = "EORI"
     val authUser: AuthorisedUser = AuthorisedUser("test", "test")
+    val accountNumber            = "12345"
 
     val standingAuthority: StandingAuthority           = StandingAuthority("EORI", startDate, Some(endDate), viewBalance = false)
     val standingAuthorityWithXIEori: StandingAuthority =
       StandingAuthority(xiEori, startDate, Some(endDate), viewBalance = false)
+
+    val euRevokeAuthorityRequest: RevokeAuthorityRequest = RevokeAuthorityRequest(
+      accountNumber = accountNumber,
+      accountType = CdsCashAccount,
+      authorisedEori = eori,
+      authorisedUser = authUser,
+      ownerEori = euEori
+    )
+
+    val xiRevokeAuthorityRequestWithGbOwnerGG: RevokeAuthorityRequest = RevokeAuthorityRequest(
+      accountNumber = accountNumber,
+      accountType = CdsGeneralGuaranteeAccount,
+      authorisedEori = xiEori,
+      authorisedUser = authUser,
+      ownerEori = gbEori
+    )
+
+    val xiRevokeAuthorityRequestWithGbOwnerCA: RevokeAuthorityRequest = RevokeAuthorityRequest(
+      accountNumber = accountNumber,
+      accountType = CdsCashAccount,
+      authorisedEori = xiEori,
+      authorisedUser = authUser,
+      ownerEori = gbEori
+    )
+
+    val xiRevokeAuthorityRequestWithXiOwner: RevokeAuthorityRequest = RevokeAuthorityRequest(
+      accountNumber = accountNumber,
+      accountType = CdsDutyDefermentAccount,
+      authorisedEori = xiEori,
+      authorisedUser = authUser,
+      ownerEori = xiEori
+    )
 
     val accountsWithAuthoritiesWithId: AccountWithAuthoritiesWithId =
       AccountWithAuthoritiesWithId(CdsCashAccount, "12345", Some(AccountStatusOpen), Map("b" -> standingAuthority))

--- a/test/services/add/AddAuthorityValidationServiceSpec.scala
+++ b/test/services/add/AddAuthorityValidationServiceSpec.scala
@@ -53,8 +53,14 @@ class AddAuthorityValidationServiceSpec extends SpecBase {
         val service: AddAuthorityValidationService = application.injector.instanceOf[AddAuthorityValidationService]
 
         running(application) {
-          service.validate(userAnswers) mustBe Option(
-            AddAuthorityRequest(Accounts(Some("12345"), Seq.empty, None), standingAuthority, authUser)
+          service.validate(userAnswers, ownerEori) mustBe Option(
+            AddAuthorityRequest(
+              Accounts(Some("12345"), Seq.empty, None),
+              standingAuthority,
+              authUser,
+              editRequest = false,
+              ownerEori
+            )
           )
         }
 
@@ -75,7 +81,7 @@ class AddAuthorityValidationServiceSpec extends SpecBase {
         val service: AddAuthorityValidationService = application.injector.instanceOf[AddAuthorityValidationService]
 
         running(application) {
-          service.validate(userAnswers) mustBe empty
+          service.validate(userAnswers, ownerEori) mustBe empty
         }
       }
     }
@@ -113,10 +119,11 @@ trait SetUp {
     .success
     .value
 
+  val ownerEori      = "GB12345"
   val year           = 2023
   val monthOfTheYear = 6
   val dayOfTheMonth  = 12
 
-  val startDate         = LocalDate.of(year, monthOfTheYear, dayOfTheMonth)
-  val standingAuthority = StandingAuthority("someEori", startDate, None, viewBalance = false)
+  val startDate: LocalDate                 = LocalDate.of(year, monthOfTheYear, dayOfTheMonth)
+  val standingAuthority: StandingAuthority = StandingAuthority("someEori", startDate, None, viewBalance = false)
 }

--- a/test/services/edit/EditAuthorityValidationServiceSpec.scala
+++ b/test/services/edit/EditAuthorityValidationServiceSpec.scala
@@ -54,20 +54,20 @@ class EditAuthorityValidationServiceSpec extends SpecBase {
         val service: EditAuthorityValidationService = application.injector.instanceOf[EditAuthorityValidationService]
 
         running(application) {
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority) mustBe
+          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority, ownerEori) mustBe
             Right(
-              AddAuthorityRequest(Accounts(Some(accountNumberVal), Seq.empty, None), standingAuthority, authUser, true)
+              AddAuthorityRequest(Accounts(Some(accountNumberVal), Seq.empty, None), standingAuthority, authUser, true, "GB12345")
             )
 
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority02) mustBe
-            Right(AddAuthorityRequest(Accounts(None, Seq(accountNumberVal), None), standingAuthority, authUser, true))
+          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority02, ownerEori) mustBe
+            Right(AddAuthorityRequest(Accounts(None, Seq(accountNumberVal), None), standingAuthority, authUser, true, "GB12345"))
 
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority03) mustBe
+          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority03, ownerEori) mustBe
             Right(
-              AddAuthorityRequest(Accounts(None, Seq.empty, Some(accountNumberVal)), standingAuthority, authUser, true)
+              AddAuthorityRequest(Accounts(None, Seq.empty, Some(accountNumberVal)), standingAuthority, authUser, true, "GB12345")
             )
 
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority04) mustBe
+          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority04, ownerEori) mustBe
             Left(UnknownAccountType)
         }
       }
@@ -88,7 +88,7 @@ class EditAuthorityValidationServiceSpec extends SpecBase {
         val service: EditAuthorityValidationService = application.injector.instanceOf[EditAuthorityValidationService]
 
         running(application) {
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority) mustBe Left(
+          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority, ownerEori) mustBe Left(
             UnknownAccountType
           )
         }
@@ -103,6 +103,7 @@ trait SetUp {
   val authorityIdVal    = "1234567"
   val authorisedEoriVal = "GB098765432109"
   val accountNumberVal  = "12345"
+  val ownerEori         = "GB12345"
 
   val mockECYAService: EditCheckYourAnswersValidationService = mock[EditCheckYourAnswersValidationService]
 

--- a/test/services/edit/EditAuthorityValidationServiceSpec.scala
+++ b/test/services/edit/EditAuthorityValidationServiceSpec.scala
@@ -56,18 +56,59 @@ class EditAuthorityValidationServiceSpec extends SpecBase {
         running(application) {
           service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority, ownerEori) mustBe
             Right(
-              AddAuthorityRequest(Accounts(Some(accountNumberVal), Seq.empty, None), standingAuthority, authUser, true, "GB12345")
+              AddAuthorityRequest(
+                Accounts(Some(accountNumberVal), Seq.empty, None),
+                standingAuthority,
+                authUser,
+                true,
+                "GB12345"
+              )
             )
 
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority02, ownerEori) mustBe
-            Right(AddAuthorityRequest(Accounts(None, Seq(accountNumberVal), None), standingAuthority, authUser, true, "GB12345"))
-
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority03, ownerEori) mustBe
+          service.validate(
+            userAnswers,
+            accountIdVal,
+            authorityIdVal,
+            authorisedEoriVal,
+            accAuthority02,
+            ownerEori
+          ) mustBe
             Right(
-              AddAuthorityRequest(Accounts(None, Seq.empty, Some(accountNumberVal)), standingAuthority, authUser, true, "GB12345")
+              AddAuthorityRequest(
+                Accounts(None, Seq(accountNumberVal), None),
+                standingAuthority,
+                authUser,
+                true,
+                "GB12345"
+              )
             )
 
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority04, ownerEori) mustBe
+          service.validate(
+            userAnswers,
+            accountIdVal,
+            authorityIdVal,
+            authorisedEoriVal,
+            accAuthority03,
+            ownerEori
+          ) mustBe
+            Right(
+              AddAuthorityRequest(
+                Accounts(None, Seq.empty, Some(accountNumberVal)),
+                standingAuthority,
+                authUser,
+                true,
+                "GB12345"
+              )
+            )
+
+          service.validate(
+            userAnswers,
+            accountIdVal,
+            authorityIdVal,
+            authorisedEoriVal,
+            accAuthority04,
+            ownerEori
+          ) mustBe
             Left(UnknownAccountType)
         }
       }
@@ -88,7 +129,14 @@ class EditAuthorityValidationServiceSpec extends SpecBase {
         val service: EditAuthorityValidationService = application.injector.instanceOf[EditAuthorityValidationService]
 
         running(application) {
-          service.validate(userAnswers, accountIdVal, authorityIdVal, authorisedEoriVal, accAuthority, ownerEori) mustBe Left(
+          service.validate(
+            userAnswers,
+            accountIdVal,
+            authorityIdVal,
+            authorisedEoriVal,
+            accAuthority,
+            ownerEori
+          ) mustBe Left(
             UnknownAccountType
           )
         }


### PR DESCRIPTION
- [x] Add ownerEori to Add & Revoke AuthorityRequests
- [x] Update Endpoints in grantAccountAuthorities & revokeAccountAuthorities
- [x] Update retrieveAccountAuthorities from get to post for the eori requestBody
- [x] Update AuthorisedUserController & RemoveCheckYourAnswer
- [x] Rewrite spec to match the changes
- [x] Test UI Journey, mongo & terminal logs